### PR TITLE
fix: add typed_data import

### DIFF
--- a/lib/src/logic/zxing.dart
+++ b/lib/src/logic/zxing.dart
@@ -1,6 +1,7 @@
 import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate';
+import 'dart:typed_data';
 
 import 'package:camera/camera.dart';
 import 'package:ffi/ffi.dart';


### PR DESCRIPTION
Hi @khoren93 

First, congratulations and thanks for the excellent work! This package is really good!

Using `Flutter 3.0.5` I got errors on the Uint8List import.

This PR simply adds the missing import

**No breaking changes**