### PR TITLE
conditionally add namespace for AGP 8 support.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.markosyan.flutter_zxing'
+    }
     compileSdkVersion 31
 
     externalNativeBuild {


### PR DESCRIPTION
required for android gradle plugin >= 8.0 
same solution as official plugins use: https://github.com/flutter/packages/pull/3836