### PR TITLE
disable desktop platforms.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,12 +29,6 @@ flutter:
         ffiPlugin: true
       ios:
         ffiPlugin: true
-      linux:
-        ffiPlugin: true
-      macos:
-        ffiPlugin: true
-      windows:
-        ffiPlugin: true
 
 # Publish to pub.dev
 # flutter pub publish --dry-run


### PR DESCRIPTION
Currently the desktop platforms produce compile errors, so it's impossible for me to use the plugin. It would be nice to just disable them to allow them to use in apps which support those platforms.