### PR TITLE
feat: Makes render widget action buttons customizable

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,6 +93,14 @@ class _DemoPageState extends State<DemoPage> {
                     scanDelay: Duration(milliseconds: isMultiScan ? 50 : 500),
                     resolution: ResolutionPreset.high,
                     lensDirection: CameraLensDirection.back,
+                    flashOnIcon: const Icon(Icons.flash_on),
+                    flashOffIcon: const Icon(Icons.flash_off),
+                    flashAlwaysIcon: const Icon(Icons.flash_on),
+                    flashAutoIcon: const Icon(Icons.flash_auto),
+                    galleryIcon: const Icon(Icons.photo_library),
+                    toggleCameraIcon: const Icon(Icons.switch_camera),
+                    actionButtonsBackgroundBorderRadius: BorderRadius.circular(10),
+                    actionButtonsBackgroundColor: Colors.black.withOpacity(0.5),
                   ),
                   if (showDebugInfo)
                     DebugInfoWidget(

--- a/lib/src/ui/reader_widget.dart
+++ b/lib/src/ui/reader_widget.dart
@@ -34,6 +34,14 @@ class ReaderWidget extends StatefulWidget {
     this.showFlashlight = true,
     this.showToggleCamera = true,
     this.showGallery = true,
+    this.flashOnIcon = const Icon(Icons.flash_on),
+    this.flashOffIcon = const Icon(Icons.flash_off),
+    this.flashAlwaysIcon = const Icon(Icons.flash_on),
+    this.flashAutoIcon = const Icon(Icons.flash_auto),
+    this.galleryIcon = const Icon(Icons.photo_library),
+    this.toggleCameraIcon = const Icon(Icons.switch_camera),
+    this.actionButtonsBackgroundColor = Colors.black,
+    this.actionButtonsBackgroundBorderRadius,
     this.allowPinchZoom = true,
     this.scanDelay = const Duration(milliseconds: 1000),
     this.scanDelaySuccess = const Duration(milliseconds: 1000),
@@ -105,6 +113,30 @@ class ReaderWidget extends StatefulWidget {
 
   /// Show toggle camera
   final bool showToggleCamera;
+
+  /// Custom flash_on icon
+  final Widget flashOnIcon;
+
+  /// Custom flash_off icon
+  final Widget flashOffIcon;
+
+  /// Custom flash_always icon
+  final Widget flashAlwaysIcon;
+
+  /// Custom flash_auto icon
+  final Widget flashAutoIcon;
+
+  /// Custom gallery icon
+  final Widget galleryIcon;
+
+  /// Custom camera toggle icon
+  final Widget toggleCameraIcon;
+
+  /// Custom background color for action buttons
+  final Color actionButtonsBackgroundColor;
+  
+  /// Custom background border radius for action buttons
+  final BorderRadius? actionButtonsBackgroundBorderRadius;
 
   /// Allow pinch zoom
   final bool allowPinchZoom;
@@ -400,9 +432,10 @@ class _ReaderWidgetState extends State<ReaderWidget>
             child: Padding(
               padding: widget.actionButtonsPadding,
               child: ClipRRect(
-                borderRadius: BorderRadius.circular(10),
+                borderRadius: widget.actionButtonsBackgroundBorderRadius
+                    ?? BorderRadius.circular(10.0),
                 child: Container(
-                  color: Colors.black.withOpacity(0.5),
+                  color: widget.actionButtonsBackgroundColor,
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
@@ -410,22 +443,19 @@ class _ReaderWidgetState extends State<ReaderWidget>
                         IconButton(
                           onPressed: _onFlashButtonTapped,
                           color: Colors.white,
-                          icon: Icon(
-                            _flashIcon(
-                                controller?.value.flashMode ?? FlashMode.off),
-                          ),
+                          icon: _flashIcon(controller?.value.flashMode ?? FlashMode.off),
                         ),
                       if (widget.showGallery)
                         IconButton(
                           onPressed: _onGalleryButtonTapped,
                           color: Colors.white,
-                          icon: const Icon(Icons.photo_library),
+                          icon: widget.galleryIcon,
                         ),
                       if (widget.showToggleCamera)
                         IconButton(
                           onPressed: _onCameraButtonTapped,
                           color: Colors.white,
-                          icon: const Icon(Icons.switch_camera),
+                          icon: widget.toggleCameraIcon,
                         ),
                     ],
                   ),
@@ -506,16 +536,16 @@ class _ReaderWidgetState extends State<ReaderWidget>
     onNewCameraSelected(selectedCamera);
   }
 
-  IconData _flashIcon(FlashMode mode) {
+  Widget _flashIcon(FlashMode mode) {
     switch (mode) {
       case FlashMode.torch:
-        return Icons.flash_on;
+        return widget.flashOnIcon;
       case FlashMode.off:
-        return Icons.flash_off;
+        return widget.flashOffIcon;
       case FlashMode.always:
-        return Icons.flash_on;
+        return widget.flashAlwaysIcon;
       case FlashMode.auto:
-        return Icons.flash_auto;
+        return widget.flashAutoIcon;
     }
   }
 


### PR DESCRIPTION
### Overview:
Action buttons(torch, gallery, toggle camera) present in the `ReaderWidget` are not customizable, this PR helps in making them customizable. This PR also makes the action buttons background color and background border radius customizable. 

All the fields are declared in the ReaderWidget class parameters also contains a default parameter values.

The following are the fields that are being newly added to the class paramters:
```
  /// Custom flash_on icon
  final Widget flashOnIcon;

  /// Custom flash_off icon
  final Widget flashOffIcon;

  /// Custom flash_always icon
  final Widget flashAlwaysIcon;

  /// Custom flash_auto icon
  final Widget flashAutoIcon;

  /// Custom gallery icon
  final Widget galleryIcon;

  /// Custom camera toggle icon
  final Widget toggleCameraIcon;

  /// Custom background color for action buttons
  final Color actionButtonsBackgroundColor;

  /// Custom background border radius for action buttons
  final BorderRadius? actionButtonsBackgroundBorderRadius;
```

Example Code:
```
ReaderWidget(
  //....
  flashOnIcon: const Icon(Icons.flash_on),              
  flashOffIcon: const Icon(Icons.flash_off),              
  flashAlwaysIcon: const Icon(Icons.flash_on),
  flashAutoIcon: const Icon(Icons.flash_auto),
  galleryIcon: const Icon(Icons.photo_library),
  toggleCameraIcon: const Icon(Icons.switch_camera),
  actionButtonsBackgroundBorderRadius: BorderRadius.circular(10),
  actionButtonsBackgroundColor: Colors.black.withOpacity(0.5),
  //....
 )
```

Closes:
#132 