### PR TITLE
ffi: fix use-after-free

### DIFF
--- a/lib/generated_bindings.dart
+++ b/lib/generated_bindings.dart
@@ -109,7 +109,7 @@ class GeneratedBindings {
 
 /// @brief The BarcodeParams class encapsulates parameters for reading barcodes.
 final class DecodeBarcodeParams extends ffi.Struct {
-  /// < Image bytes
+  /// < Image bytes. Owned pointer, freed in destructor.
   external ffi.Pointer<ffi.Uint8> bytes;
 
   /// < Image format
@@ -159,7 +159,7 @@ final class DecodeBarcodeParams extends ffi.Struct {
 
 /// @brief The EncodeBarcodeParams class encapsulates parameters for encoding barcodes.
 final class EncodeBarcodeParams extends ffi.Struct {
-  /// < The string to encode
+  /// < The string to encode. Owned pointer, freed in destructor.
   external ffi.Pointer<ffi.Char> contents;
 
   /// < The width of the barcode in pixels

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <codecvt>
 #include <cstdarg>
-#include <cstdlib>
 #include <locale>
 #include <string>
 #include <vector>
@@ -27,10 +26,6 @@ ImageView createCroppedImageView(const struct DecodeBarcodeParams &params)
     {
         image = image.cropped(params.cropLeft, params.cropTop, params.cropWidth, params.cropHeight);
     }
-
-    // Dart passes us an owned image bytes pointer; we need to free it after
-    delete[] params.bytes;
-
     return image;
 }
 

--- a/src/native_zxing.h
+++ b/src/native_zxing.h
@@ -1,8 +1,10 @@
 #ifdef __cplusplus
 #include <cstdint>
+#include <cstdlib>
 #else
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #endif
 
 #ifdef __cplusplus
@@ -15,7 +17,7 @@ extern "C"
      */
     struct DecodeBarcodeParams
     {
-        uint8_t *bytes;     ///< Image bytes
+        uint8_t *bytes;     ///< Image bytes. Owned pointer, freed in destructor.
         int imageFormat; ///< Image format
         int format;      ///< Specify a set of BarcodeFormats that should be searched for
         int width;       ///< Image width in pixels
@@ -27,6 +29,18 @@ extern "C"
         bool tryHarder;   ///< Spend more time to try to find a barcode, optimize for accuracy, not speed
         bool tryRotate;   ///< Also try detecting code in 90, 180 and 270 degree rotated images
         bool tryInvert;   ///< Try inverting the image
+
+#ifdef __cplusplus
+        ~DecodeBarcodeParams() {
+            // Dart passes us an owned image bytes pointer; we need to free it.
+            free(bytes);
+        }
+
+        DecodeBarcodeParams(const DecodeBarcodeParams&) = delete;
+        DecodeBarcodeParams& operator=(const DecodeBarcodeParams&) = delete;
+        DecodeBarcodeParams(DecodeBarcodeParams&&) = delete;
+        DecodeBarcodeParams& operator=(DecodeBarcodeParams&&) = delete;
+#endif
     };
 
     /**
@@ -34,12 +48,24 @@ extern "C"
      */
     struct EncodeBarcodeParams
     {
-        char *contents; ///< The string to encode
+        char *contents; ///< The string to encode. Owned pointer, freed in destructor.
         int width;      ///< The width of the barcode in pixels
         int height;     ///< The height of the barcode in pixels
         int format;     ///< The format of the barcode
         int margin;     ///< The margin of the barcode
         int eccLevel;   ///< The error correction level of the barcode. Used for Aztec, PDF417, and QRCode only, [0-8].
+
+#ifdef __cplusplus
+        ~EncodeBarcodeParams() {
+            // Dart passes us an owned string; we need to free it.
+            free(contents);
+        }
+
+        EncodeBarcodeParams(const EncodeBarcodeParams&) = delete;
+        EncodeBarcodeParams& operator=(const EncodeBarcodeParams&) = delete;
+        EncodeBarcodeParams(EncodeBarcodeParams&&) = delete;
+        EncodeBarcodeParams& operator=(EncodeBarcodeParams&&) = delete;
+#endif
     };
 
     /**


### PR DESCRIPTION
The `ImageView` _borrows_ from the image buffer in `DecodeBarcodeParams` -- the newly refactored code frees it too early.

To help prevent some of these issues in the future, we'll be a bit clearer that `DecodeBarcodeParams` _owns_ the buffer and actually free it in the destructor. Same with `EncodeBarcodeParams` and `contents`.

I've also disabled the copy/move constructors so we don't accidentally double free or free a nullptr.