### PR TITLE
ffi: linux support. ci: add build + integration test to CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,40 +1,116 @@
 name: Flutter CI
 
-# This workflow is triggered on pushes to the repository.
+# Trigger CI on (1) pull requests and (2) pushes to main.
 on:
+  pull_request:
   push:
     branches:
       - main
 
+# Workflows run on a PR should cancel previous workflows run on the same PR, but
+# NOT workflows running elsewhere (master).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: read-all
+
 jobs:
-  build:
-    # This job will run on ubuntu virtual machine
+  # Lint and format all the *.dart code.
+  lint:
     runs-on: ubuntu-latest
     steps:
-      # Setup Java environment in order to build the Android app.
       - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+      - uses: bluefireteam/melos-action@v3
+        with:
+          run-bootstrap: true
+          enforce-lockfile: true
+
+      - run: dart format --set-exit-if-changed .
+      - run: dart analyze
+
+  # Build the example application across all supported platforms.
+  build-example:
+    name: 'build-example (${{ matrix.target }}, ${{ matrix.os}})'
+    runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: android
+            os: ubuntu
+          - target: ios
+            os: macos
+          - target: macos
+            os: macos
+          - target: linux
+            os: ubuntu
+          - target: windows
+            os: windows
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # (Android-only) Setup java
       - uses: actions/setup-java@v4.2.1
+        if: matrix.target == 'android'
         with:
           java-version: 11
           distribution: temurin
 
-      # Setup the flutter environment.
+      # (Linux-only) Install required Flutter dependencies
+      - name: 'Setup Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y cmake dbus libblkid-dev libgtk-3-dev liblzma-dev ninja-build pkg-config xvfb
+          sudo apt install -y network-manager upower
+        if: matrix.target == 'linux'
+
+      # Setup flutter
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
           cache: true
 
-      # Setup the melos environment.
+      # Setup melos
       - uses: bluefireteam/melos-action@v3
+        with:
+          run-bootstrap: true
+          enforce-lockfile: true
 
-      - name: Install dependencies
-        run: melos bootstrap
+      - name: 'Build example ${{ matrix.target }}'
+        run: |
+          flutter config --enable-windows-desktop
+          flutter config --enable-macos-desktop
+          flutter config --enable-linux-desktop
 
-      - name: Verify formatting
-        run: dart format .
+          cd example
+          TARGET=${{ matrix.target }}
 
-      - name: Analyze project source
-        run: dart analyze
-
-      # - name: Run tests
-      #   run: dart test
+          case $TARGET in
+            ios)
+              flutter build ios --no-codesign
+              ;;
+            macos)
+              flutter build macos
+              ;;
+            android)
+              flutter build appbundle
+              ;;
+            linux)
+              flutter build linux
+              ;;
+            windows)
+              flutter build windows
+              ;;
+          esac

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,28 +53,32 @@ jobs:
             os: macos
           - target: linux
             os: ubuntu
-          - target: windows
-            os: windows
-
+          # Windows build failing
+          # - target: windows
+          #   os: windows
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      # (Android-only) Setup java
-      - uses: actions/setup-java@v4.2.1
+      - name: (iOS/macOS-only) Copy zxing src to ios/macos flutter build dir
+        if: matrix.target == 'ios' || matrix.target == 'macos'
+        run: ./scripts/update_ios_macos_src.sh
+
+      - name: (Android-only) Setup Java
+        uses: actions/setup-java@v4
         if: matrix.target == 'android'
         with:
           java-version: 11
           distribution: temurin
 
-      # (Linux-only) Install required Flutter dependencies
-      - name: 'Setup Linux'
+      - name: (Linux-only) Install Flutter apt dependencies
+        if: matrix.target == 'linux' && matrix.os == 'ubuntu'
         run: |
           sudo apt update
-          sudo apt install -y cmake dbus libblkid-dev libgtk-3-dev liblzma-dev ninja-build pkg-config xvfb
-          sudo apt install -y network-manager upower
-        if: matrix.target == 'linux'
+          sudo apt install -y \
+            cmake dbus libblkid-dev libgtk-3-dev liblzma-dev ninja-build \
+            pkg-config xvfb network-manager upower
 
       # Setup flutter
       - uses: subosito/flutter-action@v2
@@ -90,27 +94,171 @@ jobs:
 
       - name: 'Build example ${{ matrix.target }}'
         run: |
-          flutter config --enable-windows-desktop
-          flutter config --enable-macos-desktop
-          flutter config --enable-linux-desktop
-
           cd example
           TARGET=${{ matrix.target }}
 
           case $TARGET in
             ios)
-              flutter build ios --no-codesign
+              flutter build ios --debug --no-codesign
               ;;
             macos)
-              flutter build macos
+              flutter build macos --debug
               ;;
             android)
-              flutter build appbundle
+              flutter build appbundle --debug
               ;;
             linux)
-              flutter build linux
+              flutter build linux --debug
               ;;
-            windows)
-              flutter build windows
-              ;;
+          # Windows build failing
+          #   windows)
+          #     flutter build windows --debug
+          #     ;;
           esac
+
+  # Run `cd ./example && flutter test integration_test` across supported
+  # platforms, (except android, which has its own flow below).
+  test-example:
+    name: 'test-example (${{ matrix.target }}, ${{ matrix.os }})'
+    runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: ios
+            os: macos
+            device: iphone
+
+          - target: macos
+            os: macos
+            device: macos
+
+          - target: linux
+            os: ubuntu
+            device: linux
+
+          # Windows build failing
+          # - target: windows
+          #   os: windows
+          #   device: windows
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: (iOS/macOS-only) Copy zxing src to ios/macos flutter build dir
+        if: matrix.target == 'ios' || matrix.target == 'macos'
+        run: ./scripts/update_ios_macos_src.sh
+
+      # Setup flutter
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      # Setup melos
+      - uses: bluefireteam/melos-action@v3
+        with:
+          run-bootstrap: true
+          enforce-lockfile: true
+
+      - name: (Linux-only) Install Flutter apt dependencies
+        if: matrix.target == 'linux' && matrix.os == 'ubuntu'
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            cmake dbus libblkid-dev libgtk-3-dev liblzma-dev ninja-build \
+            pkg-config xvfb network-manager upower
+
+      - name: (iOS-only) Launch iOS simulator
+        if: matrix.target == 'ios'
+        run: |
+          # # List available iOS simulator devices and runtimes
+          # xcrun simctl list devices available --json
+          simulator_id=$(xcrun simctl create iphone-zxing \
+            com.apple.CoreSimulator.SimDeviceType.iPhone-15 \
+            com.apple.CoreSimulator.SimRuntime.iOS-17-5)
+          xcrun simctl boot ${simulator_id}
+
+      - run: flutter devices
+
+      - if: matrix.target != 'linux'
+        run: cd ./example && flutter test integration_test -d "${{ matrix.device }}" --verbose
+      - if: matrix.target == 'linux'
+        run: cd ./example && xvfb-run flutter test integration_test -d "${{ matrix.device }}" --verbose
+
+  # Run `cd ./example && flutter test integration_test` on an Android emulator.
+  # Android has a lot of extra steps, so it has its own section.
+  test-example-android:
+    name: 'test-example (android v${{ matrix.api-level}}, ubuntu)'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [21]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+
+      # Setup flutter
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      # Setup melos
+      - uses: bluefireteam/melos-action@v3
+        with:
+          run-bootstrap: true
+          enforce-lockfile: true
+
+      # Enable nested virtualization so we can run an Android emulator VM
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Gradle cache
+      - uses: gradle/actions/setup-gradle@v3
+
+      - name: Setup AVD actions/cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create and cache AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      # Run tests on the android emulator
+      - name: flutter test integration_test
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            flutter devices
+            cd ./example && flutter test integration_test --verbose

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Flutter ZXing supports the following platforms:
 - iOS (minimum iOS 11.0)
 - MacOS (minimum osx 10.15) (beta)
 - Linux (working, but [no camera support](https://pub.dev/packages/camera)) (alpha)
-- Windows (working, but [no camera support](https://pub.dev/packages/camera)) (alpha)
+- Windows (not working yet)
 - Web (not working yet)
 
 Note that flutter_zxing relies on the Dart FFI (Foreign Function Interface) feature, which is currently only available for the mobile and desktop platforms. As a result, the plugin is not currently supported on the web platform.
@@ -84,8 +84,7 @@ melos bootstrap
 To allow the building on iOS and MacOS, you need to run the following command:
 
 ```bash
-cd scripts
-sh update_ios_macos_src.sh
+./scripts/update_ios_macos_src.sh
 ```
 
 To run the integration tests:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Flutter ZXing supports the following platforms:
 - Android (minimum API level 21)
 - iOS (minimum iOS 11.0)
 - MacOS (minimum osx 10.15) (beta)
-- Linux (not working yet)
-- Windows (not working yet)
+- Linux (working, but [no camera support](https://pub.dev/packages/camera)) (alpha)
+- Windows (working, but [no camera support](https://pub.dev/packages/camera)) (alpha)
 - Web (not working yet)
 
 Note that flutter_zxing relies on the Dart FFI (Foreign Function Interface) feature, which is currently only available for the mobile and desktop platforms. As a result, the plugin is not currently supported on the web platform.
@@ -86,6 +86,13 @@ To allow the building on iOS and MacOS, you need to run the following command:
 ```bash
 cd scripts
 sh update_ios_macos_src.sh
+```
+
+To run the integration tests:
+
+```bash
+cd example
+flutter test integration_test
 ```
 
 Now you can run the flutter_zxing example app on your device or emulator.

--- a/example/integration_test/ffi_test.dart
+++ b/example/integration_test/ffi_test.dart
@@ -1,0 +1,124 @@
+/// FFI integration tests
+///
+/// Ensure each FFI call actually works on each supported platform
+/// (android, macos, ios, linux, windows) end-to-end.
+library;
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart' show expect, test;
+import 'package:flutter_zxing/flutter_zxing.dart'
+    show DecodeParams, EccLevel, EncodeParams, Format, ImageFormat, zx;
+
+void main() async {
+  test('Zxing.setLogEnabled', () => zx.setLogEnabled(false));
+
+  test('Zxing.version', () {
+    assert(zx.version().isNotEmpty);
+  });
+
+  test('Zxing.encodeBarcode -> readBarcode(s)', () {
+    const contents = "This is a QR code";
+
+    // Encode a QR code image
+
+    final encodeParams = EncodeParams(
+      format: Format.qrCode,
+      width: 100,
+      height: 100,
+      margin: 0,
+      eccLevel: EccLevel.low,
+    );
+
+    final enc = zx.encodeBarcode(contents: contents, params: encodeParams);
+
+    assert(enc.isValid);
+    expect(enc.format, encodeParams.format);
+    expect(enc.text, contents);
+    assert(enc.data != null);
+    assert(enc.length! > 0);
+
+    final dataU32 = enc.data!;
+    expect(dataU32.length, encodeParams.width * encodeParams.height);
+
+    // Decode the image (no multiscan)
+
+    final decodeParams = DecodeParams(
+      imageFormat: ImageFormat.rgbx,
+      format: encodeParams.format,
+      width: encodeParams.width,
+      height: encodeParams.height,
+      isMultiScan: false,
+    );
+    final dataU8 = dataU32.buffer.asUint8List();
+    final code1 = zx.readBarcode(dataU8, decodeParams);
+
+    assert(code1.isValid);
+    expect(code1.error, null);
+    expect(code1.text, contents);
+    expect(code1.format, encodeParams.format);
+    expect(code1.isInverted, false);
+    expect(code1.isMirrored, false);
+
+    // Decode the image (multiscan)
+
+    final decodeParams2 = DecodeParams(
+      imageFormat: ImageFormat.rgbx,
+      format: encodeParams.format,
+      width: encodeParams.width,
+      height: encodeParams.height,
+      isMultiScan: true,
+    );
+    final results = zx.readBarcodes(dataU8, decodeParams2);
+
+    expect(results.error, null);
+    expect(results.codes.length, 1);
+
+    final code2 = results.codes.first;
+    expect(code2.isValid, code1.isValid);
+    expect(code2.error, code1.error);
+    expect(code2.text, code1.text);
+    expect(code2.rawBytes, code1.rawBytes);
+    expect(code2.format, code1.format);
+    expect(code2.isInverted, code1.isInverted);
+    expect(code2.isMirrored, code1.isMirrored);
+  });
+
+  test('Zxing.readBarcode(s) (bad image)', () {
+    // Build an empty, white image
+    const width = 100;
+    const height = 100;
+    final whiteImage = Uint32List(width * height);
+    whiteImage.fillRange(0, whiteImage.length, 0xffffffff);
+
+    // Decode the image (no multiscan)
+    final decodeParams = DecodeParams(
+      imageFormat: ImageFormat.rgbx,
+      format: Format.qrCode,
+      width: width,
+      height: height,
+      isMultiScan: false,
+    );
+    final dataU8 = whiteImage.buffer.asUint8List();
+    final code1 = zx.readBarcode(dataU8, decodeParams);
+
+    assert(!code1.isValid);
+    expect(code1.error, "");
+    expect(code1.text, null);
+    expect(code1.format, Format.none);
+    expect(code1.isInverted, false);
+    expect(code1.isMirrored, false);
+
+    // Decode the image (multiscan)
+    final decodeParams2 = DecodeParams(
+      imageFormat: ImageFormat.rgbx,
+      format: Format.qrCode,
+      width: width,
+      height: height,
+      isMultiScan: true,
+    );
+    final results = zx.readBarcodes(dataU8, decodeParams2);
+    expect(results.error, null);
+    expect(results.codes, []);
+  });
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   file_selector_linux:
     dependency: transitive
     description:
@@ -158,6 +166,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -191,6 +204,11 @@ packages:
       relative: true
     source: path
     version: "1.6.1"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   http:
     dependency: transitive
     description:
@@ -279,6 +297,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -359,6 +382,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -367,6 +398,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -412,6 +451,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -460,6 +507,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   xml:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,6 +16,8 @@ dev_dependencies:
   flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/lib/flutter_zxing.dart
+++ b/lib/flutter_zxing.dart
@@ -48,7 +48,7 @@ abstract class Zxing {
   /// Reads barcode from image url
   Future<Code> readBarcodeImageUrl(String url, DecodeParams params);
 
-// Reads barcode from Uint8List image bytes
+  /// Reads barcode from Uint8List image bytes
   Code readBarcode(Uint8List bytes, DecodeParams params);
 
   /// Reads barcodes from String image path

--- a/lib/generated_bindings.dart
+++ b/lib/generated_bindings.dart
@@ -291,9 +291,6 @@ final class EncodeResult extends ffi.Struct {
   @ffi.Bool()
   external bool isValid;
 
-  /// < The encoded text. Owned pointer. Must be freed by Dart code if not null.
-  external ffi.Pointer<ffi.Char> text;
-
   /// < The format of the barcode
   @ffi.Int()
   external int format;

--- a/lib/generated_bindings.dart
+++ b/lib/generated_bindings.dart
@@ -56,55 +56,61 @@ class GeneratedBindings {
       _versionPtr.asFunction<ffi.Pointer<ffi.Char> Function()>();
 
   /// @brief Read barcode from image bytes.
-  /// @param params Barcode parameters.
+  /// @param params Barcode parameters. Owned pointer. Will be freed before
+  /// function returns.
   /// @return The barcode result.
   CodeResult readBarcode(
-    DecodeBarcodeParams params,
+    ffi.Pointer<DecodeBarcodeParams> params,
   ) {
     return _readBarcode(
       params,
     );
   }
 
-  late final _readBarcodePtr =
-      _lookup<ffi.NativeFunction<CodeResult Function(DecodeBarcodeParams)>>(
-          'readBarcode');
-  late final _readBarcode =
-      _readBarcodePtr.asFunction<CodeResult Function(DecodeBarcodeParams)>();
+  late final _readBarcodePtr = _lookup<
+      ffi.NativeFunction<
+          CodeResult Function(
+              ffi.Pointer<DecodeBarcodeParams>)>>('readBarcode');
+  late final _readBarcode = _readBarcodePtr
+      .asFunction<CodeResult Function(ffi.Pointer<DecodeBarcodeParams>)>();
 
   /// @brief Read barcodes from image bytes.
-  /// @param params Barcode parameters.
+  /// @param params Barcode parameters. Owned pointer. Will be freed before
+  /// function returns.
   /// @return The barcode results.
   CodeResults readBarcodes(
-    DecodeBarcodeParams params,
+    ffi.Pointer<DecodeBarcodeParams> params,
   ) {
     return _readBarcodes(
       params,
     );
   }
 
-  late final _readBarcodesPtr =
-      _lookup<ffi.NativeFunction<CodeResults Function(DecodeBarcodeParams)>>(
-          'readBarcodes');
-  late final _readBarcodes =
-      _readBarcodesPtr.asFunction<CodeResults Function(DecodeBarcodeParams)>();
+  late final _readBarcodesPtr = _lookup<
+      ffi.NativeFunction<
+          CodeResults Function(
+              ffi.Pointer<DecodeBarcodeParams>)>>('readBarcodes');
+  late final _readBarcodes = _readBarcodesPtr
+      .asFunction<CodeResults Function(ffi.Pointer<DecodeBarcodeParams>)>();
 
   /// @brief Encode a string into a barcode
-  /// @param params The parameters for encoding the barcode
+  /// @param params Encoding parameters. Owned pointer. Will be freed before
+  /// function returns.
   /// @return The barcode data
   EncodeResult encodeBarcode(
-    EncodeBarcodeParams params,
+    ffi.Pointer<EncodeBarcodeParams> params,
   ) {
     return _encodeBarcode(
       params,
     );
   }
 
-  late final _encodeBarcodePtr =
-      _lookup<ffi.NativeFunction<EncodeResult Function(EncodeBarcodeParams)>>(
-          'encodeBarcode');
+  late final _encodeBarcodePtr = _lookup<
+      ffi.NativeFunction<
+          EncodeResult Function(
+              ffi.Pointer<EncodeBarcodeParams>)>>('encodeBarcode');
   late final _encodeBarcode = _encodeBarcodePtr
-      .asFunction<EncodeResult Function(EncodeBarcodeParams)>();
+      .asFunction<EncodeResult Function(ffi.Pointer<EncodeBarcodeParams>)>();
 }
 
 /// @brief The BarcodeParams class encapsulates parameters for reading barcodes.

--- a/lib/src/logic/barcode_encoder.dart
+++ b/lib/src/logic/barcode_encoder.dart
@@ -5,4 +5,6 @@ Encode zxingEncodeBarcode({
   required String contents,
   required EncodeParams params,
 }) =>
-    bindings.encodeBarcode(params.toEncodeBarcodeParams(contents)).toEncode();
+    bindings
+        .encodeBarcode(params.toEncodeBarcodeParams(contents))
+        .toEncode(contents);

--- a/lib/src/logic/bindings.dart
+++ b/lib/src/logic/bindings.dart
@@ -4,7 +4,7 @@ final GeneratedBindings bindings = GeneratedBindings(dylib);
 
 // Getting a library that holds needed symbols
 DynamicLibrary _openDynamicLibrary() {
-  if (Platform.isAndroid) {
+  if (Platform.isAndroid || Platform.isLinux) {
     return DynamicLibrary.open('libflutter_zxing.so');
   } else if (Platform.isWindows) {
     return DynamicLibrary.open('flutter_zxing_windows_plugin.dll');

--- a/lib/src/utils/extentions.dart
+++ b/lib/src/utils/extentions.dart
@@ -63,10 +63,10 @@ extension CodeExt on CodeResult {
 }
 
 extension EncodeExt on EncodeResult {
-  Encode toEncode() => Encode(
+  Encode toEncode(final String text) => Encode(
         isValid,
         format,
-        copyStringFromOwnedFfiPtr(text),
+        text,
         copyUint32ListFromOwnedFfiPtr(data, length),
         length,
         copyStringFromOwnedFfiPtr(error),

--- a/lib/src/utils/extentions.dart
+++ b/lib/src/utils/extentions.dart
@@ -89,7 +89,7 @@ extension PosExt on Pos {
 }
 
 extension EncodeParamsExt on EncodeParams {
-  EncodeBarcodeParams toEncodeBarcodeParams(String contents) {
+  Pointer<EncodeBarcodeParams> toEncodeBarcodeParams(String contents) {
     final Pointer<EncodeBarcodeParams> p = calloc<EncodeBarcodeParams>();
     p.ref.contents = contents.toNativeUtf8().cast<Char>();
     p.ref.width = width;
@@ -97,12 +97,12 @@ extension EncodeParamsExt on EncodeParams {
     p.ref.format = format;
     p.ref.margin = margin;
     p.ref.eccLevel = eccLevel.value;
-    return p.ref;
+    return p;
   }
 }
 
 extension DecodeParamsExt on DecodeParams {
-  DecodeBarcodeParams toDecodeBarcodeParams(Uint8List bytes) {
+  Pointer<DecodeBarcodeParams> toDecodeBarcodeParams(Uint8List bytes) {
     final Pointer<DecodeBarcodeParams> p = calloc<DecodeBarcodeParams>();
     p.ref.bytes = bytes.copyToNativePointer();
     p.ref.imageFormat = imageFormat;
@@ -116,6 +116,6 @@ extension DecodeParamsExt on DecodeParams {
     p.ref.tryHarder = tryHarder;
     p.ref.tryRotate = tryRotate;
     p.ref.tryInvert = tryInverted;
-    return p.ref;
+    return p;
   }
 }

--- a/scripts/update_ios_macos_src.sh
+++ b/scripts/update_ios_macos_src.sh
@@ -1,22 +1,28 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
 # This script copies the source files from the src directory to the ios and macos directories.
 # Should be run every time the src directory files are updated.
 
-srcPath="../src" 
-zxingPath="$srcPath/zxing/core/src"
-iosSrcPath="../ios/Classes/src"
-macosSrcPath="../macos/Classes/src"
+REPO_DIR="$(git rev-parse --show-toplevel)"
+
+SRC_DIR="$REPO_DIR/src"
+ZXING_SRC_DIR="$REPO_DIR/src/zxing/core/src"
+IOS_SRC_DIR="$REPO_DIR/ios/Classes/src"
+MACOS_SRC_PATH="$REPO_DIR/macos/Classes/src"
 
 # Remove the source files if they exist
-rm -rf $iosSrcPath
-rm -rf $macosSrcPath
+rm -rf "$IOS_SRC_DIR"
+rm -rf "$MACOS_SRC_PATH"
 
 # create the source directories
-mkdir -p $iosSrcPath
-mkdir -p $macosSrcPath
+mkdir -p "$IOS_SRC_DIR"
+mkdir -p "$MACOS_SRC_PATH"
 
 # Copy the source files
-rsync -av --exclude '*.txt' --exclude "zxing/" "$srcPath/" "$iosSrcPath/" 
-rsync -av "$zxingPath/" "$iosSrcPath/zxing/"
+rsync -av --exclude '*.txt' --exclude "zxing/" "$SRC_DIR/" "$IOS_SRC_DIR/"
+rsync -av "$ZXING_SRC_DIR/" "$IOS_SRC_DIR/zxing/"
 
-rsync -av --exclude '*.txt' --exclude "zxing/" "$srcPath/" "$macosSrcPath/" 
-rsync -av "$zxingPath/" "$macosSrcPath/zxing/"
+rsync -av --exclude '*.txt' --exclude "zxing/" "$SRC_DIR/" "$MACOS_SRC_PATH/"
+rsync -av "$ZXING_SRC_DIR/" "$MACOS_SRC_PATH/zxing/"

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -11,7 +11,7 @@ void setLoggingEnabled(bool enabled)
         isLogEnabled = enabled;
 }
 
-void platform_log(const char *fmt, ...)
+void platform_log(const char* fmt, ...)
 {
         if (isLogEnabled)
         {
@@ -20,7 +20,7 @@ void platform_log(const char *fmt, ...)
 #ifdef __ANDROID__
                 __android_log_vprint(ANDROID_LOG_VERBOSE, "ndk", fmt, args);
 #elif defined(IS_WIN32)
-                char *buf = new char[4096];
+                char* buf = new char[4096];
                 std::fill_n(buf, 4096, '\0');
                 _vsprintf_p(buf, 4096, fmt, args);
                 OutputDebugStringA(buf);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2,16 +2,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-using namespace std;
-
 bool isLogEnabled;
 
-void setLoggingEnabled(bool enabled)
+void setLoggingEnabled(bool enabled) noexcept
 {
         isLogEnabled = enabled;
 }
 
-void platform_log(const char* fmt, ...)
+void platform_log(const char* fmt, ...) noexcept
 {
         if (isLogEnabled)
         {
@@ -26,7 +24,8 @@ void platform_log(const char* fmt, ...)
                 OutputDebugStringA(buf);
                 delete[] buf;
 #else
-                vprintf(fmt, args);
+                // vprintf(fmt, args);
+                vfprintf(stderr, fmt, args);
 #endif
                 va_end(args);
         }

--- a/src/common.h
+++ b/src/common.h
@@ -19,6 +19,6 @@
 #define FUNCTION_ATTRIBUTE __declspec(dllexport)
 #endif
 
-void platform_log(const char *fmt, ...);
+void platform_log(const char* fmt, ...);
 
 void setLoggingEnabled(bool enabled);

--- a/src/common.h
+++ b/src/common.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
 #define IS_WIN32

--- a/src/common.h
+++ b/src/common.h
@@ -20,6 +20,6 @@
 #define FUNCTION_ATTRIBUTE __declspec(dllexport)
 #endif
 
-void platform_log(const char* fmt, ...);
+void platform_log(const char* fmt, ...) noexcept;
 
-void setLoggingEnabled(bool enabled);
+void setLoggingEnabled(bool enabled) noexcept;

--- a/src/dart_alloc.h
+++ b/src/dart_alloc.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <memory>
+
+#ifdef IS_WIN32
+#include <Windows.h>
+#else
+#include <cstdlib>
+#endif
+
+/// `dart_allocator` is a `std::allocator` impl that can:
+///
+/// (1) safely allocate memory in C++ that is later freed inside the Dart VM
+/// (2) safely free memory in C++ that was earlier allocated inside the Dart VM
+///
+/// On Unix-like systems, this uses the libc allocator fns `malloc` and `free`. On
+/// Windows, this uses `CoTaskMemAlloc` and `CoTaskMemFree`.
+///
+/// !! You must use this allocator _exclusively_ to manage every owned pointer
+/// !! that crosses to/from Dart.
+///
+/// See: <https://pub.dev/documentation/ffi/latest/ffi/malloc-constant.html>
+template <typename T>
+class dart_allocator {
+public:
+    typedef T value_type;
+
+    dart_allocator() = default;
+
+    template <class U>
+    constexpr dart_allocator(const dart_allocator<U>&) noexcept {}
+
+    /// Allocates `n * sizeof(T)` bytes of uninit memory on the same global
+    /// allocator as the Dart VM.
+    [[nodiscard]]
+    T* allocate(std::size_t n)
+    {
+#ifdef IS_WIN32
+        T* p = static_cast<T*>(CoTaskMemAlloc(n * sizeof(T)));
+#else
+        T* p = static_cast<T*>(std::malloc(n * sizeof(T)));
+#endif
+        if (t == nullptr) {
+            throw std::bad_alloc();
+        }
+
+        return p;
+    }
+
+    /// Deallocates `p` from the Dart VM global allocator.
+    void deallocate(T* p, std::size_t n) noexcept
+    {
+#ifdef IS_WIN32
+        CoTaskMemFree(p);
+#else
+        std::free(p);
+#endif
+    }
+};
+
+template <class T, class U>
+constexpr bool operator==(const dart_allocator<T>&, const dart_allocator<U>&) { return true; }
+
+template <class T, class U>
+constexpr bool operator!=(const dart_allocator<T>&, const dart_allocator<U>&) { return false; }
+
+/// Convenience fn. See `dart_allocator<T>::allocate`.
+template <typename T>
+[[nodiscard]]
+T* dart_malloc(std::size_t n)
+{
+    return dart_allocator<T>{}.allocate(n);
+}
+
+/// Convenience fn. See `dart_allocator<T>::deallocate`.
+template <typename T>
+void dart_free(T* p)
+{
+    dart_allocator<T>{}.deallocate(p, 1 /* wrong but unused value */);
+}
+
+/// A "deleter" for `std::unique_ptr` that can free pointers from Dart.
+struct dart_deleter {
+    template <typename T>
+    void operator()(T* p) const
+    {
+        dart_allocator<T>{}.deallocate(p, 1);
+    }
+};
+
+/// `unique_dart_ptr` is a `unique_ptr` that can safely manage pointers allocated
+/// from within Dart. In particular, it will dealloc pointers passed from Dart
+/// using the same allocator that alloc'd them.
+template <typename T>
+using unique_dart_ptr = std::unique_ptr<T, dart_deleter>;
+
+// Ensure `unique_dart_ptr` doesn't add any extra fn ptr overhead. It should
+// just be ptr-sized.
+static_assert(
+    sizeof(std::unique_ptr<uint8_t>) == sizeof(unique_dart_ptr<uint8_t>),
+    "no extra overhead"
+);

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -164,13 +164,11 @@ CodeResult codeResultFromResult(
     auto bl = p.bottomLeft();
     auto br = p.bottomRight();
 
-    const auto text = result.text();
-
     CodeResult code {};
-    code.text = dartCstrFromString(text);
     code.isValid = result.isValid();
-    code.error = dartCstrFromString(result.error().msg());
-    code.bytes = dartBytesFromVector(result.bytes());
+    code.text = result.isValid() ? dartCstrFromString(result.text()) : nullptr;
+    code.bytes = result.isValid() ? dartBytesFromVector(result.bytes()) : nullptr;
+    code.error = result.isValid() ? nullptr : dartCstrFromString(result.error().msg());
     code.length = static_cast<int>(result.bytes().size());
     code.format = static_cast<int>(result.format());
     code.pos = Pos{width, height, tl.x, tl.y, tr.x, tr.y, bl.x, bl.y, br.x, br.y};

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -66,8 +66,14 @@ extern "C"
 
 ImageView createCroppedImageView(const DecodeBarcodeParams &params)
 {
-    ImageView image {reinterpret_cast<const uint8_t *>(params.bytes), params.width, params.height, ImageFormat(params.imageFormat)};
-    if (params.cropWidth > 0 && params.cropHeight > 0 && params.cropWidth < params.width && params.cropHeight < params.height)
+    ImageView image {
+        reinterpret_cast<const uint8_t *>(params.bytes),
+        params.width,
+        params.height,
+        ImageFormat(params.imageFormat),
+    };
+    if (params.cropWidth > 0 && params.cropHeight > 0
+        && params.cropWidth < params.width && params.cropHeight < params.height)
     {
         image = image.cropped(params.cropLeft, params.cropTop, params.cropWidth, params.cropHeight);
     }
@@ -76,7 +82,12 @@ ImageView createCroppedImageView(const DecodeBarcodeParams &params)
 
 ReaderOptions createReaderOptions(const DecodeBarcodeParams &params)
 {
-    return ReaderOptions().setTryHarder(params.tryHarder).setTryRotate(params.tryRotate).setFormats(BarcodeFormat(params.format)).setTryInvert(params.tryInvert).setReturnErrors(true);
+    return ReaderOptions()
+        .setTryHarder(params.tryHarder)
+        .setTryRotate(params.tryRotate)
+        .setFormats(BarcodeFormat(params.format))
+        .setTryInvert(params.tryInvert)
+        .setReturnErrors(true);
 }
 
 // Returns an owned C-string `char*`, copied from a `std::string&`.
@@ -187,7 +198,10 @@ EncodeResult _encodeBarcode(const EncodeBarcodeParams& params)
     EncodeResult result {0, params.contents, params.format, nullptr, 0, nullptr};
     try
     {
-        auto writer = MultiFormatWriter(BarcodeFormat(params.format)).setMargin(params.margin).setEccLevel(params.eccLevel).setEncoding(CharacterSet::UTF8);
+        auto writer = MultiFormatWriter(BarcodeFormat(params.format))
+           .setMargin(params.margin)
+           .setEccLevel(params.eccLevel)
+           .setEncoding(CharacterSet::UTF8);
         auto bitMatrix = writer.encode(params.contents, params.width, params.height);
         auto matrix = ToMatrix<uint8_t>(bitMatrix);
 

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -17,7 +17,52 @@ using namespace ZXing;
 using namespace std;
 using std::chrono::steady_clock;
 
+// Forward declare some impls
+CodeResult _readBarcode(const DecodeBarcodeParams& params);
+CodeResults _readBarcodes(const DecodeBarcodeParams& params);
+EncodeResult _encodeBarcode(const EncodeBarcodeParams& params);
+
+//
+// Public, exported FFI functions
+//
+
+extern "C"
+{
+    FUNCTION_ATTRIBUTE
+    void setLogEnabled(bool enable)
+    {
+        setLoggingEnabled(enable);
+    }
+
+    FUNCTION_ATTRIBUTE
+    char const *version()
+    {
+        // return ZXING_VERSION_STR; // TODO: Not working on iOS for now
+        return "2.2.1";
+    }
+
+    FUNCTION_ATTRIBUTE
+    struct CodeResult readBarcode(struct DecodeBarcodeParams params)
+    {
+        return _readBarcode(params);
+    }
+
+    FUNCTION_ATTRIBUTE
+    struct CodeResults readBarcodes(struct DecodeBarcodeParams params)
+    {
+        return _readBarcodes(params);
+    }
+
+    FUNCTION_ATTRIBUTE
+    struct EncodeResult encodeBarcode(struct EncodeBarcodeParams params)
+    {
+        return _encodeBarcode(params);
+    }
+}
+
+//
 // Helper functions
+//
 
 ImageView createCroppedImageView(const struct DecodeBarcodeParams &params)
 {
@@ -94,95 +139,78 @@ int elapsed_ms(const steady_clock::time_point &start)
     return chrono::duration_cast<chrono::milliseconds>(duration).count();
 }
 
-extern "C"
+//
+// FFI impls
+//
+
+CodeResult _readBarcode(const DecodeBarcodeParams& params)
 {
+    auto start = steady_clock::now();
 
-    FUNCTION_ATTRIBUTE
-    void setLogEnabled(bool enable)
+    ImageView image = createCroppedImageView(params);
+    ReaderOptions hints = createReaderOptions(params);
+    Result result = ReadBarcode(image, hints);
+
+    int duration = elapsed_ms(start);
+    platform_log("Read Barcode in: %d ms\n", duration);
+    return codeResultFromResult(result, duration, params.width, params.height);
+}
+
+CodeResults _readBarcodes(const DecodeBarcodeParams& params)
+{
+    auto start = steady_clock::now();
+
+    ImageView image = createCroppedImageView(params);
+    ReaderOptions hints = createReaderOptions(params);
+    Results results = ReadBarcodes(image, hints);
+
+    int duration = elapsed_ms(start);
+    platform_log("Read Barcode in: %d ms\n", duration);
+
+    if (results.empty())
     {
-        setLoggingEnabled(enable);
+        return CodeResults{0, nullptr, duration};
     }
 
-    FUNCTION_ATTRIBUTE
-    char const *version()
+    auto *codes = new struct CodeResult[results.size()];
+    int i = 0;
+    for (const auto &result : results)
     {
-        // return ZXING_VERSION_STR; // TODO: Not working on iOS for now
-        return "2.2.1";
+        codes[i] = codeResultFromResult(result, duration, params.width, params.height);
+        i++;
+    }
+    return CodeResults{i, codes, duration};
+}
+
+EncodeResult _encodeBarcode(const EncodeBarcodeParams& params)
+{
+    auto start = steady_clock::now();
+
+    struct EncodeResult result = {0, params.contents, params.format, nullptr, 0, nullptr};
+    try
+    {
+        auto writer = MultiFormatWriter(BarcodeFormat(params.format)).setMargin(params.margin).setEccLevel(params.eccLevel).setEncoding(CharacterSet::UTF8);
+        auto bitMatrix = writer.encode(params.contents, params.width, params.height);
+        auto matrix = ToMatrix<uint8_t>(bitMatrix);
+
+        // We need to return an owned pointer across the ffi boundary. Copy
+        // the output (again).
+        auto length = matrix.size();
+        auto *data = new uint8_t[length];
+        std::copy(matrix.begin(), matrix.end(), data);
+
+        result.length = length;
+        result.data = data;
+        result.isValid = true;
+    }
+    catch (const exception &e)
+    {
+        platform_log("Can't encode text: %s\nError: %s\n", params.contents, e.what());
+        result.error = new char[strlen(e.what()) + 1];
+        strcpy(result.error, e.what());
     }
 
-    FUNCTION_ATTRIBUTE
-    struct CodeResult readBarcode(struct DecodeBarcodeParams params)
-    {
-        auto start = steady_clock::now();
-
-        ImageView image = createCroppedImageView(params);
-        ReaderOptions hints = createReaderOptions(params);
-        Result result = ReadBarcode(image, hints);
-
-        int duration = elapsed_ms(start);
-        platform_log("Read Barcode in: %d ms\n", duration);
-        return codeResultFromResult(result, duration, params.width, params.height);
-        ;
-    }
-
-    FUNCTION_ATTRIBUTE
-    struct CodeResults readBarcodes(struct DecodeBarcodeParams params)
-    {
-        auto start = steady_clock::now();
-
-        ImageView image = createCroppedImageView(params);
-        ReaderOptions hints = createReaderOptions(params);
-        Results results = ReadBarcodes(image, hints);
-
-        int duration = elapsed_ms(start);
-        platform_log("Read Barcode in: %d ms\n", duration);
-
-        if (results.empty())
-        {
-            return CodeResults{0, nullptr, duration};
-        }
-
-        auto *codes = new struct CodeResult[results.size()];
-        int i = 0;
-        for (const auto &result : results)
-        {
-            codes[i] = codeResultFromResult(result, duration, params.width, params.height);
-            i++;
-        }
-        return CodeResults{i, codes, duration};
-    }
-
-    FUNCTION_ATTRIBUTE
-    struct EncodeResult encodeBarcode(struct EncodeBarcodeParams params)
-    {
-        auto start = steady_clock::now();
-
-        struct EncodeResult result = {0, params.contents, params.format, nullptr, 0, nullptr};
-        try
-        {
-            auto writer = MultiFormatWriter(BarcodeFormat(params.format)).setMargin(params.margin).setEccLevel(params.eccLevel).setEncoding(CharacterSet::UTF8);
-            auto bitMatrix = writer.encode(params.contents, params.width, params.height);
-            auto matrix = ToMatrix<uint8_t>(bitMatrix);
-
-            // We need to return an owned pointer across the ffi boundary. Copy
-            // the output (again).
-            auto length = matrix.size();
-            auto *data = new uint8_t[length];
-            std::copy(matrix.begin(), matrix.end(), data);
-
-            result.length = length;
-            result.data = data;
-            result.isValid = true;
-        }
-        catch (const exception &e)
-        {
-            platform_log("Can't encode text: %s\nError: %s\n", params.contents, e.what());
-            result.error = new char[strlen(e.what()) + 1];
-            strcpy(result.error, e.what());
-        }
-
-        int duration = elapsed_ms(start);
-        platform_log("Encode Barcode in: %d ms\n", duration);
-        return result;
-    }
+    int duration = elapsed_ms(start);
+    platform_log("Encode Barcode in: %d ms\n", duration);
+    return result;
 }

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -33,9 +33,9 @@ using namespace std;
 using std::chrono::steady_clock;
 
 // Forward declare some impls
-CodeResult _readBarcode(const DecodeBarcodeParams& params);
-CodeResults _readBarcodes(const DecodeBarcodeParams& params);
-EncodeResult _encodeBarcode(const EncodeBarcodeParams& params);
+CodeResult _readBarcode(const DecodeBarcodeParams& params) noexcept;
+CodeResults _readBarcodes(const DecodeBarcodeParams& params) noexcept;
+EncodeResult _encodeBarcode(const EncodeBarcodeParams& params) noexcept;
 
 //
 // Public, exported FFI functions
@@ -44,34 +44,34 @@ EncodeResult _encodeBarcode(const EncodeBarcodeParams& params);
 extern "C"
 {
     FUNCTION_ATTRIBUTE
-    void setLogEnabled(bool enable)
+    void setLogEnabled(bool enable) noexcept
     {
         setLoggingEnabled(enable);
     }
 
     FUNCTION_ATTRIBUTE
-    char const* version()
+    char const* version() noexcept
     {
         // return ZXING_VERSION_STR; // TODO: Not working on iOS for now
         return "2.2.1";
     }
 
     FUNCTION_ATTRIBUTE
-    CodeResult readBarcode(DecodeBarcodeParams* params)
+    CodeResult readBarcode(DecodeBarcodeParams* params) noexcept
     {
         unique_dart_ptr<DecodeBarcodeParams> _params(params);
         return _readBarcode(*_params);
     }
 
     FUNCTION_ATTRIBUTE
-    CodeResults readBarcodes(DecodeBarcodeParams* params)
+    CodeResults readBarcodes(DecodeBarcodeParams* params) noexcept
     {
         unique_dart_ptr<DecodeBarcodeParams> _params(params);
         return _readBarcodes(*_params);
     }
 
     FUNCTION_ATTRIBUTE
-    EncodeResult encodeBarcode(EncodeBarcodeParams* params)
+    EncodeResult encodeBarcode(EncodeBarcodeParams* params) noexcept
     {
         unique_dart_ptr<EncodeBarcodeParams> _params(params);
         return _encodeBarcode(*_params);
@@ -112,16 +112,16 @@ ReaderOptions createReaderOptions(const DecodeBarcodeParams& params)
 /// The owned pointer is safe to send back to Dart.
 char* dartCstrFromString(const std::string& s)
 {
-    auto size = s.length() + 1;
-    auto* out = dart_malloc<char>(size);
+    auto len = s.length();
+    auto* out = dart_malloc<char>(len + 1);
     std::copy(s.begin(), s.end(), out);
-    out[size - 1] = '\0';
+    out[len] = '\0';
     return out;
 }
 
 /// Returns an owned C-string `char*` copied from the `exception::what()` message.
 /// The owned pointer is safe to send back to Dart.
-char* dartCstrFromException(const exception& e)
+char* dartCstrFromException(const exception& e) noexcept
 {
     auto* s = e.what();
     auto len = strlen(s);
@@ -193,7 +193,7 @@ int elapsed_ms(const steady_clock::time_point& start)
 // FFI impls
 //
 
-CodeResult _readBarcode(const DecodeBarcodeParams& params)
+CodeResult _readBarcode(const DecodeBarcodeParams& params) noexcept
 {
     // Absolutely ensure we don't unwind across the FFI boundary.
     try
@@ -218,7 +218,7 @@ CodeResult _readBarcode(const DecodeBarcodeParams& params)
     }
 }
 
-CodeResults _readBarcodes(const DecodeBarcodeParams& params)
+CodeResults _readBarcodes(const DecodeBarcodeParams& params) noexcept
 {
     // Absolutely ensure we don't unwind across the FFI boundary.
     try
@@ -253,7 +253,7 @@ CodeResults _readBarcodes(const DecodeBarcodeParams& params)
     }
 }
 
-EncodeResult _encodeBarcode(const EncodeBarcodeParams& params)
+EncodeResult _encodeBarcode(const EncodeBarcodeParams& params) noexcept
 {
     // Absolutely ensure we don't unwind across the FFI boundary.
     try

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -42,21 +42,21 @@ extern "C"
     }
 
     FUNCTION_ATTRIBUTE
-    CodeResult readBarcode(DecodeBarcodeParams params)
+    CodeResult readBarcode(DecodeBarcodeParams* params)
     {
-        return _readBarcode(params);
+        return _readBarcode(*params);
     }
 
     FUNCTION_ATTRIBUTE
-    CodeResults readBarcodes(DecodeBarcodeParams params)
+    CodeResults readBarcodes(DecodeBarcodeParams* params)
     {
-        return _readBarcodes(params);
+        return _readBarcodes(*params);
     }
 
     FUNCTION_ATTRIBUTE
-    EncodeResult encodeBarcode(EncodeBarcodeParams params)
+    EncodeResult encodeBarcode(EncodeBarcodeParams* params)
     {
-        return _encodeBarcode(params);
+        return _encodeBarcode(*params);
     }
 }
 

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -230,7 +230,7 @@ EncodeResult _encodeBarcode(const EncodeBarcodeParams& params)
 {
     auto start = steady_clock::now();
 
-    EncodeResult result {0, params.contents, params.format, nullptr, 0, nullptr};
+    EncodeResult result {0, params.format, nullptr, 0, nullptr};
     try
     {
         auto writer = MultiFormatWriter(BarcodeFormat(params.format))

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -34,7 +34,7 @@ EncodeResult _encodeBarcode(const EncodeBarcodeParams& params);
 // See: <https://pub.dev/documentation/ffi/latest/ffi/malloc-constant.html>
 struct dart_deleter {
     template <typename T>
-    void operator()(T *p) const;
+    void operator()(T* p) const;
 };
 template <typename T>
 using unique_dart_ptr = std::unique_ptr<T, dart_deleter>;
@@ -52,7 +52,7 @@ extern "C"
     }
 
     FUNCTION_ATTRIBUTE
-    char const *version()
+    char const* version()
     {
         // return ZXING_VERSION_STR; // TODO: Not working on iOS for now
         return "2.2.1";
@@ -84,10 +84,10 @@ extern "C"
 // Helper functions
 //
 
-ImageView createCroppedImageView(const DecodeBarcodeParams &params)
+ImageView createCroppedImageView(const DecodeBarcodeParams& params)
 {
     ImageView image {
-        reinterpret_cast<const uint8_t *>(params.bytes),
+        reinterpret_cast<const uint8_t*>(params.bytes),
         params.width,
         params.height,
         ImageFormat(params.imageFormat),
@@ -100,7 +100,7 @@ ImageView createCroppedImageView(const DecodeBarcodeParams &params)
     return image;
 }
 
-ReaderOptions createReaderOptions(const DecodeBarcodeParams &params)
+ReaderOptions createReaderOptions(const DecodeBarcodeParams& params)
 {
     return ReaderOptions()
         .setTryHarder(params.tryHarder)
@@ -111,7 +111,7 @@ ReaderOptions createReaderOptions(const DecodeBarcodeParams &params)
 }
 
 // Returns an owned C-string `char*`, copied from a `std::string&`.
-char *cstrFromString(const std::string &s)
+char* cstrFromString(const std::string& s)
 {
     auto size = s.length() + 1;
     char *out = new char[size];
@@ -122,9 +122,9 @@ char *cstrFromString(const std::string &s)
 
 // Returns an owned byte buffer `uint8_t*`, copied from a
 // `std::vector<uint8_t>&`.
-uint8_t *bytesFromVector(const std::vector<uint8_t> &v)
+uint8_t* bytesFromVector(const std::vector<uint8_t>& v)
 {
-    auto *bytes = new uint8_t[v.size()];
+    auto* bytes = new uint8_t[v.size()];
     std::copy(v.begin(), v.end(), bytes);
     return bytes;
 }
@@ -132,7 +132,7 @@ uint8_t *bytesFromVector(const std::vector<uint8_t> &v)
 // Construct a `CodeResult` from a zxing barcode decode `Result` from within an
 // image.
 CodeResult codeResultFromResult(
-    const Result &result,
+    const Result& result,
     int duration,
     int width,
     int height)
@@ -161,7 +161,7 @@ CodeResult codeResultFromResult(
 }
 
 // Returns the duration elapsed in milliseconds since `start`.
-int elapsed_ms(const steady_clock::time_point &start)
+int elapsed_ms(const steady_clock::time_point& start)
 {
     auto end = steady_clock::now();
     auto duration = end - start;
@@ -170,7 +170,7 @@ int elapsed_ms(const steady_clock::time_point &start)
 
 // A "deleter" for `std::unique_ptr` that can free pointers from Dart.
 template <typename T>
-void dart_deleter::operator()(T *p) const
+void dart_deleter::operator()(T* p) const
 {
     // TODO(phlip9): this should use `CoTaskMemFree` on Windows
     std::free(const_cast<std::remove_const_t<T>*>(p));
@@ -213,7 +213,7 @@ CodeResults _readBarcodes(const DecodeBarcodeParams& params)
 
     if (results.empty())
     {
-        return CodeResults{0, nullptr, duration};
+        return CodeResults {0, nullptr, duration};
     }
 
     auto *codes = new CodeResult[results.size()];
@@ -223,7 +223,7 @@ CodeResults _readBarcodes(const DecodeBarcodeParams& params)
         codes[i] = codeResultFromResult(result, duration, params.width, params.height);
         i++;
     }
-    return CodeResults{i, codes, duration};
+    return CodeResults {i, codes, duration};
 }
 
 EncodeResult _encodeBarcode(const EncodeBarcodeParams& params)
@@ -250,7 +250,7 @@ EncodeResult _encodeBarcode(const EncodeBarcodeParams& params)
         result.data = data;
         result.isValid = true;
     }
-    catch (const exception &e)
+    catch (const exception& e)
     {
         platform_log("Can't encode text: %s\nError: %s\n", params.contents, e.what());
         result.error = new char[strlen(e.what()) + 1];

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -42,19 +42,19 @@ extern "C"
     }
 
     FUNCTION_ATTRIBUTE
-    struct CodeResult readBarcode(struct DecodeBarcodeParams params)
+    CodeResult readBarcode(DecodeBarcodeParams params)
     {
         return _readBarcode(params);
     }
 
     FUNCTION_ATTRIBUTE
-    struct CodeResults readBarcodes(struct DecodeBarcodeParams params)
+    CodeResults readBarcodes(DecodeBarcodeParams params)
     {
         return _readBarcodes(params);
     }
 
     FUNCTION_ATTRIBUTE
-    struct EncodeResult encodeBarcode(struct EncodeBarcodeParams params)
+    EncodeResult encodeBarcode(EncodeBarcodeParams params)
     {
         return _encodeBarcode(params);
     }
@@ -64,9 +64,9 @@ extern "C"
 // Helper functions
 //
 
-ImageView createCroppedImageView(const struct DecodeBarcodeParams &params)
+ImageView createCroppedImageView(const DecodeBarcodeParams &params)
 {
-    ImageView image{reinterpret_cast<const uint8_t *>(params.bytes), params.width, params.height, ImageFormat(params.imageFormat)};
+    ImageView image {reinterpret_cast<const uint8_t *>(params.bytes), params.width, params.height, ImageFormat(params.imageFormat)};
     if (params.cropWidth > 0 && params.cropHeight > 0 && params.cropWidth < params.width && params.cropHeight < params.height)
     {
         image = image.cropped(params.cropLeft, params.cropTop, params.cropWidth, params.cropHeight);
@@ -74,7 +74,7 @@ ImageView createCroppedImageView(const struct DecodeBarcodeParams &params)
     return image;
 }
 
-ReaderOptions createReaderOptions(const struct DecodeBarcodeParams &params)
+ReaderOptions createReaderOptions(const DecodeBarcodeParams &params)
 {
     return ReaderOptions().setTryHarder(params.tryHarder).setTryRotate(params.tryRotate).setFormats(BarcodeFormat(params.format)).setTryInvert(params.tryInvert).setReturnErrors(true);
 }
@@ -114,9 +114,7 @@ CodeResult codeResultFromResult(
 
     const auto text = result.text();
 
-    struct CodeResult code
-    {
-    };
+    CodeResult code {};
     code.text = cstrFromString(text);
     code.isValid = result.isValid();
     code.error = cstrFromString(result.error().msg());
@@ -172,7 +170,7 @@ CodeResults _readBarcodes(const DecodeBarcodeParams& params)
         return CodeResults{0, nullptr, duration};
     }
 
-    auto *codes = new struct CodeResult[results.size()];
+    auto *codes = new CodeResult[results.size()];
     int i = 0;
     for (const auto &result : results)
     {
@@ -186,7 +184,7 @@ EncodeResult _encodeBarcode(const EncodeBarcodeParams& params)
 {
     auto start = steady_clock::now();
 
-    struct EncodeResult result = {0, params.contents, params.format, nullptr, 0, nullptr};
+    EncodeResult result {0, params.contents, params.format, nullptr, 0, nullptr};
     try
     {
         auto writer = MultiFormatWriter(BarcodeFormat(params.format)).setMargin(params.margin).setEccLevel(params.eccLevel).setEncoding(CharacterSet::UTF8);

--- a/src/native_zxing.h
+++ b/src/native_zxing.h
@@ -143,24 +143,27 @@ extern "C"
 
     /**
      * @brief Read barcode from image bytes.
-     * @param params Barcode parameters.
+     * @param params Barcode parameters. Owned pointer. Will be freed before
+     *               function returns.
      * @return The barcode result.
      */
-    struct CodeResult readBarcode(struct DecodeBarcodeParams params);
+    struct CodeResult readBarcode(struct DecodeBarcodeParams* params);
 
     /**
      * @brief Read barcodes from image bytes.
-     * @param params Barcode parameters.
+     * @param params Barcode parameters. Owned pointer. Will be freed before
+     *               function returns.
      * @return The barcode results.
      */
-    struct CodeResults readBarcodes(struct DecodeBarcodeParams params);
+    struct CodeResults readBarcodes(struct DecodeBarcodeParams* params);
 
     /**
      * @brief Encode a string into a barcode
-     * @param params The parameters for encoding the barcode
+     * @param params Encoding parameters. Owned pointer. Will be freed before
+     *               function returns.
      * @return The barcode data
      */
-    struct EncodeResult encodeBarcode(struct EncodeBarcodeParams params);
+    struct EncodeResult encodeBarcode(struct EncodeBarcodeParams* params);
 
 #ifdef __cplusplus
 }

--- a/src/native_zxing.h
+++ b/src/native_zxing.h
@@ -12,6 +12,12 @@
 #endif
 
 #ifdef __cplusplus
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
+#endif
+
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -35,7 +41,7 @@ extern "C"
         bool tryInvert;  ///< Try inverting the image
 
 #ifdef __cplusplus
-        ~DecodeBarcodeParams() {
+        ~DecodeBarcodeParams() noexcept {
             // Dart passes us an owned image bytes pointer; we need to free it.
             dart_free(bytes);
         }
@@ -60,7 +66,7 @@ extern "C"
         int eccLevel;   ///< The error correction level of the barcode. Used for Aztec, PDF417, and QRCode only, [0-8].
 
 #ifdef __cplusplus
-        ~EncodeBarcodeParams() {
+        ~EncodeBarcodeParams() noexcept {
             // Dart passes us an owned string; we need to free it.
             dart_free(contents);
         }
@@ -135,14 +141,14 @@ extern "C"
      *
      * @param enabled Whether to enable or disable the logging.
      */
-    void setLogEnabled(bool enabled);
+    void setLogEnabled(bool enabled) NOEXCEPT;
 
     /**
      * Returns the version of the zxing-cpp library. Pointer has a static lifetime and must not be freed.
      *
      * @return The version of the zxing-cpp library.
      */
-    char const* version();
+    char const* version() NOEXCEPT;
 
     /**
      * @brief Read barcode from image bytes.
@@ -150,7 +156,7 @@ extern "C"
      *               function returns.
      * @return The barcode result.
      */
-    struct CodeResult readBarcode(struct DecodeBarcodeParams* params);
+    struct CodeResult readBarcode(struct DecodeBarcodeParams* params) NOEXCEPT;
 
     /**
      * @brief Read barcodes from image bytes.
@@ -158,7 +164,7 @@ extern "C"
      *               function returns.
      * @return The barcode results.
      */
-    struct CodeResults readBarcodes(struct DecodeBarcodeParams* params);
+    struct CodeResults readBarcodes(struct DecodeBarcodeParams* params) NOEXCEPT;
 
     /**
      * @brief Encode a string into a barcode
@@ -166,7 +172,7 @@ extern "C"
      *               function returns.
      * @return The barcode data
      */
-    struct EncodeResult encodeBarcode(struct EncodeBarcodeParams* params);
+    struct EncodeResult encodeBarcode(struct EncodeBarcodeParams* params) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/src/native_zxing.h
+++ b/src/native_zxing.h
@@ -17,7 +17,7 @@ extern "C"
      */
     struct DecodeBarcodeParams
     {
-        uint8_t *bytes;     ///< Image bytes. Owned pointer, freed in destructor.
+        uint8_t* bytes;  ///< Image bytes. Owned pointer, freed in destructor.
         int imageFormat; ///< Image format
         int format;      ///< Specify a set of BarcodeFormats that should be searched for
         int width;       ///< Image width in pixels
@@ -26,9 +26,9 @@ extern "C"
         int cropTop;     ///< Crop top
         int cropWidth;   ///< Crop width
         int cropHeight;  ///< Crop height
-        bool tryHarder;   ///< Spend more time to try to find a barcode, optimize for accuracy, not speed
-        bool tryRotate;   ///< Also try detecting code in 90, 180 and 270 degree rotated images
-        bool tryInvert;   ///< Try inverting the image
+        bool tryHarder;  ///< Spend more time to try to find a barcode, optimize for accuracy, not speed
+        bool tryRotate;  ///< Also try detecting code in 90, 180 and 270 degree rotated images
+        bool tryInvert;  ///< Try inverting the image
 
 #ifdef __cplusplus
         ~DecodeBarcodeParams() {
@@ -48,7 +48,7 @@ extern "C"
      */
     struct EncodeBarcodeParams
     {
-        char *contents; ///< The string to encode. Owned pointer, freed in destructor.
+        char* contents; ///< The string to encode. Owned pointer, freed in destructor.
         int width;      ///< The width of the barcode in pixels
         int height;     ///< The height of the barcode in pixels
         int format;     ///< The format of the barcode
@@ -91,10 +91,10 @@ extern "C"
      */
     struct CodeResult
     {
-        char *text;      ///< The decoded text. Owned pointer. Must be freed by Dart code if not null.
+        char* text;      ///< The decoded text. Owned pointer. Must be freed by Dart code if not null.
         bool isValid;    ///< Whether the barcode was successfully decoded
-        char *error;     ///< The error message. Owned pointer. Must be freed by Dart code if not null.
-        uint8_t *bytes;  ///< The bytes is the raw content without any character set conversions. Owned pointer. Must be freed by Dart code if not null.
+        char* error;     ///< The error message. Owned pointer. Must be freed by Dart code if not null.
+        uint8_t* bytes;  ///< The bytes is the raw content without any character set conversions. Owned pointer. Must be freed by Dart code if not null.
         int length;      ///< The length of the bytes
         int format;      ///< The format of the barcode
         struct Pos pos;  ///< The position of the barcode within the image
@@ -109,7 +109,7 @@ extern "C"
     struct CodeResults
     {
         int count;                  ///< The number of barcodes detected
-        struct CodeResult *results; ///< The results of the barcode decoding. Owned pointer. Must be freed by Dart code.
+        struct CodeResult* results; ///< The results of the barcode decoding. Owned pointer. Must be freed by Dart code.
         int duration;               ///< The duration of the decoding in milliseconds
     };
 
@@ -120,11 +120,11 @@ extern "C"
     struct EncodeResult
     {
         bool isValid;  ///< Whether the barcode was successfully encoded
-        char *text;    ///< The encoded text. Owned pointer. Must be freed by Dart code if not null.
+        char* text;    ///< The encoded text. Owned pointer. Must be freed by Dart code if not null.
         int format;    ///< The format of the barcode
-        uint8_t *data; ///< The encoded data. Owned pointer. Must be freed by Dart code if not null.
+        uint8_t* data; ///< The encoded data. Owned pointer. Must be freed by Dart code if not null.
         int length;    ///< The length of the encoded data
-        char *error;   ///< The error message. Owned pointer. Must be freed by Dart code if not null.
+        char* error;   ///< The error message. Owned pointer. Must be freed by Dart code if not null.
     };
 
     /**
@@ -139,7 +139,7 @@ extern "C"
      *
      * @return The version of the zxing-cpp library.
      */
-    char const *version();
+    char const* version();
 
     /**
      * @brief Read barcode from image bytes.

--- a/src/native_zxing.h
+++ b/src/native_zxing.h
@@ -120,7 +120,6 @@ extern "C"
     struct EncodeResult
     {
         bool isValid;  ///< Whether the barcode was successfully encoded
-        char* text;    ///< The encoded text. Owned pointer. Must be freed by Dart code if not null.
         int format;    ///< The format of the barcode
         uint8_t* data; ///< The encoded data. Owned pointer. Must be freed by Dart code if not null.
         int length;    ///< The length of the encoded data

--- a/src/native_zxing.h
+++ b/src/native_zxing.h
@@ -1,4 +1,8 @@
+#pragma once
+
 #ifdef __cplusplus
+#include "dart_alloc.h"
+
 #include <cstdint>
 #include <cstdlib>
 #else
@@ -33,7 +37,7 @@ extern "C"
 #ifdef __cplusplus
         ~DecodeBarcodeParams() {
             // Dart passes us an owned image bytes pointer; we need to free it.
-            free(bytes);
+            dart_free(bytes);
         }
 
         DecodeBarcodeParams(const DecodeBarcodeParams&) = delete;
@@ -58,7 +62,7 @@ extern "C"
 #ifdef __cplusplus
         ~EncodeBarcodeParams() {
             // Dart passes us an owned string; we need to free it.
-            free(contents);
+            dart_free(contents);
         }
 
         EncodeBarcodeParams(const EncodeBarcodeParams&) = delete;


### PR DESCRIPTION
Hey again! Back with another pass at fixing up the native glue code. I recently needed to run our app on a Linux machine and encountered a crash with `flutter_zxing` whenever it called `encodeBarcode`. With this PR, I can now confidently run `flutter_zxing` on Linux w/o issues!

### Overview

This PR:

1. Adds support for Linux (minus camera support, of course). Had to fix some SEGFAULTs in the native code to get this working.
2. Adds an integration test exercising the FFI code.
3. Adds `flutter build` and `flutter test integration_test` Github CI workflows running across android, iOS, macOS, and linux. Windows build fails to compile though.
4. Enforces strict allocator discipline in the native code. Memory freed in C++ from Dart must use `dart_free`. Memory freed in Dart from C++ must be allocated with `dart_malloc`.
5. Tries hard to ensure we don't throw/unwind exceptions across the FFI boundary, which is unsafe. Public FFI functions are marked `noexcept`.

I recommend reviewing by commit.