### PR TITLE
Revert "Fix memory leak by freeing owned image bytes after reading barcode"

### DIFF
--- a/src/dart_alloc.h
+++ b/src/dart_alloc.h
@@ -94,7 +94,11 @@ struct dart_deleter {
     template <typename T>
     void operator()(T* p) const noexcept
     {
-        dart_allocator<T>{}.deallocate(p, 1);
+        if (p != nullptr) {
+            // A "deleter" also needs to run p's destructor before free'ing.
+            p->~T();
+            dart_allocator<T>{}.deallocate(p, 1);
+        }
     }
 };
 

--- a/src/native_zxing.cpp
+++ b/src/native_zxing.cpp
@@ -202,9 +202,6 @@ CodeResult _readBarcode(const DecodeBarcodeParams& params) noexcept
         ReaderOptions hints = createReaderOptions(params);
         Result result = ReadBarcode(image, hints);
 
-        // Dart passes us an owned image bytes pointer; we need to free it after
-        delete[] params.bytes;
-
         int duration = elapsed_ms(start);
         platform_log("Read Barcode in: %d ms\n", duration);
         return codeResultFromResult(result, duration, params.width, params.height);
@@ -229,9 +226,6 @@ CodeResults _readBarcodes(const DecodeBarcodeParams& params) noexcept
         ImageView image = createCroppedImageView(params);
         ReaderOptions hints = createReaderOptions(params);
         Results results = ReadBarcodes(image, hints);
-
-        // Dart passes us an owned image bytes pointer; we need to free it after
-        delete[] params.bytes;
 
         int duration = elapsed_ms(start);
         platform_log("Read Barcode in: %d ms\n", duration);

--- a/src/native_zxing.h
+++ b/src/native_zxing.h
@@ -46,6 +46,7 @@ extern "C"
             dart_free(bytes);
         }
 
+        // Disable copy/move contsructors
         DecodeBarcodeParams(const DecodeBarcodeParams&) = delete;
         DecodeBarcodeParams& operator=(const DecodeBarcodeParams&) = delete;
         DecodeBarcodeParams(DecodeBarcodeParams&&) = delete;
@@ -71,6 +72,7 @@ extern "C"
             dart_free(contents);
         }
 
+        // Disable copy/move contsructors
         EncodeBarcodeParams(const EncodeBarcodeParams&) = delete;
         EncodeBarcodeParams& operator=(const EncodeBarcodeParams&) = delete;
         EncodeBarcodeParams(EncodeBarcodeParams&&) = delete;


### PR DESCRIPTION
Hey, just noticed the recent commit. Sadly it appears to introduce a double-free and/or allocator mismatch, so I've added this commit to revert. I know touching this FFI code is pretty nasty -- I wish there was an easy way to test the code with sanitizers or valgrind or something, but I think that would require recompiling the whole dart VM toolchain w/ sanitizers enabled... Until then, feel free to cc me on any PRs that touch native code. I'm happy to review : D

### Commit

> This reverts commit e187556f9a355056b8a30733fbf67bc4f64f8e9b.
>
> 1. The `DecodeBarcodeParams` struct already has a destructor that frees the `.bytes` field.
> 2. Memory needs to be free'd with `dart_free` and not `delete[]`, as libstdc++ may use a different allocator.
> 3. The `params` arg here is passed as a borrow (`const DecodeBarcodeParams&`) which should signal that the function is not meant to manage any of the resources in `params`.