### PR TITLE
Fix Windows build

### DIFF
--- a/example/windows/flutter/CMakeLists.txt
+++ b/example/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/lib/src/logic/bindings.dart
+++ b/lib/src/logic/bindings.dart
@@ -7,7 +7,7 @@ DynamicLibrary _openDynamicLibrary() {
   if (Platform.isAndroid || Platform.isLinux) {
     return DynamicLibrary.open('libflutter_zxing.so');
   } else if (Platform.isWindows) {
-    return DynamicLibrary.open('flutter_zxing_windows_plugin.dll');
+    return DynamicLibrary.open('flutter_zxing.dll');
   }
   return DynamicLibrary.process();
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(
 
 set (BUILD_WRITERS ON)
 
-add_subdirectory(zxing/core)
+add_subdirectory(zxing/core EXCLUDE_FROM_ALL)
 
 target_link_libraries(flutter_zxing ZXing)
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include <stdio.h>
 #include <stdarg.h>
+#include <algorithm>
 
 bool isLogEnabled;
 

--- a/src/common.h
+++ b/src/common.h
@@ -9,6 +9,7 @@
 #endif
 
 #ifdef IS_WIN32
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/src/dart_alloc.h
+++ b/src/dart_alloc.h
@@ -3,9 +3,9 @@
 #include <exception>
 #include <memory>
 
-#ifdef IS_WIN32
-#include <Windows.h>
-#else
+#include "common.h"
+
+#ifndef IS_WIN32
 #include <cstdlib>
 #endif
 

--- a/src/native_zxing.h
+++ b/src/native_zxing.h
@@ -17,6 +17,8 @@
 #define NOEXCEPT
 #endif
 
+#include "common.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -143,6 +145,7 @@ extern "C"
      *
      * @param enabled Whether to enable or disable the logging.
      */
+    FUNCTION_ATTRIBUTE
     void setLogEnabled(bool enabled) NOEXCEPT;
 
     /**
@@ -150,6 +153,7 @@ extern "C"
      *
      * @return The version of the zxing-cpp library.
      */
+    FUNCTION_ATTRIBUTE
     char const* version() NOEXCEPT;
 
     /**
@@ -158,6 +162,7 @@ extern "C"
      *               function returns.
      * @return The barcode result.
      */
+    FUNCTION_ATTRIBUTE
     struct CodeResult readBarcode(struct DecodeBarcodeParams* params) NOEXCEPT;
 
     /**
@@ -166,6 +171,7 @@ extern "C"
      *               function returns.
      * @return The barcode results.
      */
+    FUNCTION_ATTRIBUTE
     struct CodeResults readBarcodes(struct DecodeBarcodeParams* params) NOEXCEPT;
 
     /**
@@ -174,6 +180,7 @@ extern "C"
      *               function returns.
      * @return The barcode data
      */
+    FUNCTION_ATTRIBUTE
     struct EncodeResult encodeBarcode(struct EncodeBarcodeParams* params) NOEXCEPT;
 
 #ifdef __cplusplus


### PR DESCRIPTION
Make the necessary changes to make the plugin build on the Windows platform. Even though the [`camera_windows` plugin](https://github.com/flutter/packages/tree/main/packages/camera/camera_windows) doesn’t currently support image streaming, it may be nevertheless useful to be able to use this plugin on Windows.

The changes are relatively minor:
 - Fix linkage errors by adding `FUNCTION_ATTRIBUTE` to the function declarations.
 - Ensure that the `IS_WIN32` definition is seen where needed.
 - Work around a build failure related to the zxing library using the advice from [this comment](https://github.com/flutter/flutter/issues/95530#issuecomment-1149154998). Apparently `add_subdirectory` shouldn’t be used at all in this sort of situation, but the workaround fixes the problem for now.
 - Disable `min` and `max` macros.
