### PR TITLE
Fix: DynamicScannerOverlay > newCutOutSize

### DIFF
--- a/lib/src/ui/dynamic_scanner_overlay.dart
+++ b/lib/src/ui/dynamic_scanner_overlay.dart
@@ -3,14 +3,16 @@ import 'package:flutter/material.dart';
 import 'scanner_overlay.dart';
 
 class DynamicScannerOverlay extends ScannerOverlay {
-  const DynamicScannerOverlay({
-    super.borderColor,
-    super.borderWidth,
-    super.overlayColor,
-    super.borderRadius,
-    super.borderLength,
-    this.cutOutSize = 0.5,
-  }) : assert(cutOutSize >= 0 && cutOutSize <= 1, 'The cut out size must be between 0 and 1');
+  const DynamicScannerOverlay(
+      {super.borderColor,
+      super.borderWidth,
+      super.overlayColor,
+      super.borderRadius,
+      super.borderLength,
+      this.cutOutSize = 0.5})
+      : assert(cutOutSize >= 0 && cutOutSize <= 1,
+            'The cut out size must be between 0 and 1');
+
 
   @override
   final double cutOutSize;

--- a/lib/src/ui/dynamic_scanner_overlay.dart
+++ b/lib/src/ui/dynamic_scanner_overlay.dart
@@ -3,15 +3,14 @@ import 'package:flutter/material.dart';
 import 'scanner_overlay.dart';
 
 class DynamicScannerOverlay extends ScannerOverlay {
-  const DynamicScannerOverlay(
-      {super.borderColor,
-      super.borderWidth,
-      super.overlayColor,
-      super.borderRadius,
-      super.borderLength,
-      this.cutOutSize = 0.5})
-      : assert(cutOutSize >= 0 && cutOutSize <= 1,
-            'The cut out size must be between 0 and 1');
+  const DynamicScannerOverlay({
+    super.borderColor,
+    super.borderWidth,
+    super.overlayColor,
+    super.borderRadius,
+    super.borderLength,
+    this.cutOutSize = 0.5,
+  }) : assert(cutOutSize >= 0 && cutOutSize <= 1, 'The cut out size must be between 0 and 1');
 
   @override
   final double cutOutSize;
@@ -22,7 +21,7 @@ class DynamicScannerOverlay extends ScannerOverlay {
     final double height = rect.height;
     final double borderOffset = borderWidth / 2;
     final double newBorderLength = borderLength;
-    final double newCutOutSize = width * cutOutSize;
+    final double newCutOutSize = width < height ? width * cutOutSize : height * cutOutSize;
 
     final Paint backgroundPaint = Paint()
       ..color = overlayColor


### PR DESCRIPTION
When the phone is held in landscape mode, the cutOutSize may be larger than the screen. This causes the box to overflow at the top and bottom.
To prevent the cutOutRect from being larger than the screen, newCutOutSize now depends on the smaller of width or height.