### PR TITLE
fix: prevent zooming when the camera is off/disposed in reader widget

### DIFF
--- a/lib/src/ui/reader_widget.dart
+++ b/lib/src/ui/reader_widget.dart
@@ -423,6 +423,9 @@ class _ReaderWidgetState extends State<ReaderWidget>
               _zoom = _scaleFactor;
             },
             onScaleUpdate: (ScaleUpdateDetails details) {
+              if (!_isCameraOn) {
+                return;
+              }
               _scaleFactor =
                   (_zoom * details.scale).clamp(_minZoomLevel, _maxZoomLevel);
               controller?.setZoomLevel(_scaleFactor);


### PR DESCRIPTION
Since I could not reproduce the error, I cannot test if it is fixed. But if "_isCameraOn" has the correct state, it should not be possible to set the zoom level when the camera is disposed.