### PR TITLE
Support Android devices that use YUV420 with plane.bytesPerRow != image.width

### DIFF
--- a/lib/src/logic/camera_image.dart
+++ b/lib/src/logic/camera_image.dart
@@ -1,0 +1,37 @@
+part of 'zxing.dart';
+
+extension CameraImageExt on CameraImage {
+
+  bool hasMultiBytePixelPlane() {
+    return planes.any((Plane plane) => (plane.bytesPerPixel ?? 0) > 1);
+  }
+
+  /// Returns true if the CameraImage is a format
+  /// that is directly supported by zxing_cpp
+  /// (e.g. tightly packed YUV420 or BGRA8888).
+  bool isZxingProcessableCameraImage() {
+    return format.group == ImageFormatGroup.yuv420 ||
+        planes[0].bytesPerRow == width;
+  }
+
+  /// Converts the Y plane of a YUV420 image to a
+  /// tightly packed (no padding) grayscale list of bytes.
+  Uint8List getTightlyPackedYPlane() {
+    final Plane yPlane = planes[0];
+    final int bytesPerRow = yPlane.bytesPerRow;
+
+    // If row stride matches the image width, copy directly.
+    if (bytesPerRow == width) {
+      return yPlane.bytes;
+    }
+
+    final Uint8List packed = Uint8List(width * height);
+
+    for (int row = 0; row < height; row++) {
+      final int srcOffset = row * bytesPerRow;
+      final int dstOffset = row * width;
+      packed.setRange(dstOffset, dstOffset + width, yPlane.bytes, srcOffset);
+    }
+    return packed;
+  }
+}

--- a/lib/src/logic/zxing.dart
+++ b/lib/src/logic/zxing.dart
@@ -20,6 +20,7 @@ part 'barcode_encoder.dart';
 part 'barcode_reader.dart';
 part 'barcodes_reader.dart';
 part 'bindings.dart';
+part 'camera_image.dart';
 part 'camera_stream.dart';
 
 /// Returns a version of the zxing library

--- a/lib/src/ui/reader_widget.dart
+++ b/lib/src/ui/reader_widget.dart
@@ -8,6 +8,7 @@ import 'package:image_picker/image_picker.dart';
 
 import '../../flutter_zxing.dart';
 import '../../flutter_zxing.dart' as zxing;
+import '../logic/zxing.dart';
 import 'scan_mode_dropdown.dart';
 
 /// Widget to scan a code from the camera stream
@@ -340,7 +341,16 @@ class _ReaderWidgetState extends State<ReaderWidget>
             widget.onMultiScanFailure?.call(result);
           }
         } else {
-          final Code result = await zx.processCameraImage(image, params);
+
+          Code result;
+          if(image.isZxingProcessableCameraImage()) {
+            result = await zx.processCameraImage(image, params);
+          } else {
+            // for some devices we need to convert the image
+            // to a tightly packed Y plane
+            result = zx.readBarcode(image.getTightlyPackedYPlane(), params);
+          }
+
           if (result.isValid) {
             widget.onScan?.call(result);
             if (!mounted) {


### PR DESCRIPTION
Some devices such as the Moto G Stylus 5G (2022) provide a CameraImage that has a YUV420 image where the Y plane bytesPerRow doesn't match the image width. In these cases zxing_cpp does not seem to interpret the image correctly and fails to recognize barcodes. This workaround converts the y plane to a tightly packed Uint8List for processing in such cases, but uses the existing behavior otherwise.

Fixes #103 

Related to #141