### PR TITLE
Support 16KB page size on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:8.5.1'
     }
 }
 
@@ -27,7 +27,7 @@ android {
         namespace 'com.markosyan.flutter_zxing'
     }
     compileSdk 34
-    ndkVersion android.ndkVersion
+    ndkVersion "27.0.12077973"
 
     externalNativeBuild {
         cmake {
@@ -41,6 +41,6 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
     }
 }

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.markosyan.flutter_zxing_example"
     compileSdk = flutter.compileSdkVersion
-    // ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -24,7 +24,7 @@ android {
         applicationId = "com.markosyan.flutter_zxing_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,11 @@ target_link_libraries(flutter_zxing ZXing)
 if (ANDROID)
     find_library(log-lib log)
     target_link_libraries(flutter_zxing ${log-lib})
+
+    # The max-page-size linker option is required to enable support for 16KB page
+    # size on Android with NDK 27.x.
+    # TODO: This can be removed when NDK 28+ is used, as it defaults to 16KB.
+    target_link_options(flutter_zxing PRIVATE "-Wl,-z,max-page-size=16384")
 endif (ANDROID)
 
 # Command to update zxing submodule


### PR DESCRIPTION
Fixes #188 
Fixes #191 

Adds support for [16 KB page sizes](https://developer.android.com/guide/practices/page-sizes).

This approach requires using [NDK](https://github.com/android/ndk) version `27.x` and [Android Gradle Plugin version `8.5.1` or higher](https://developer.android.com/guide/practices/page-sizes#agp_version_851_or_higher).

I think this is acceptable, as a lot of official plugins also require NDK 27, for example [`connectivity_plus` or `shared_preferences_android`](https://stackoverflow.com/questions/79572913/flutter-android-ndk-version-conflict-plugins-require-27-0-12077973-but-project).

Additionally the `minSdkVersion` had to be bumped to API Level 23 (Android 6.0), because we need the *shared objects* to be page aligned and uncompressed. This is the default behavior with AGP 8.5.1+ and minSdkVersion 23, as explained in the documentation for [`useLegacyPackaging`](https://developer.android.com/reference/tools/gradle-api/8.12/com/android/build/api/dsl/JniLibsPackaging#useLegacyPackaging()). If we don't upgrade the minSdkVersion, users would be required to specify `useLegacyPackaging = false` in their gradle configuration for their apps which I think would be less ergonomic and not as obvious. Apart from that I think loosing Android 5 support should be acceptable nowadays as this version does not receive security updates anymore for more than 7 years at this point.

### Testing
In order to test this change with Android Studios' [APK Analyzer](https://developer.android.com/studio/debug/apk-analyzer) be sure to completely clean the example project using `cd example && flutter clean` and to manually delete the folders `android/.cxx` and `example/android/.gradle`.
Then run `flutter build apk` and open it from the *APK Analyzer*.

Please note that I had mixed results on MacOS (where sometimes 16KB page size support would be reported on the current `main` branch as well), for which reason I recommend testing this change on Windows.