### PR TITLE
Add support for Android 16KB Page Size

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,10 @@ android {
 
     defaultConfig {
         minSdkVersion 21
+        externalNativeBuild {
+            cmake {
+                arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix for #191.

Add support for [16KB page size](https://developer.android.com/guide/practices/page-sizes?hl=en), which [must be supported before November 1st](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html).

The [ZXing C++ library](https://github.com/zxing-cpp/zxing-cpp) uses AGP 8.7.3, so the default NDK version is 27.0.12077973.
According to [this guidance](https://developer.android.com/guide/practices/page-sizes?hl=en#compile-r27), we need to add the following CMake argument: `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON`.

### APK Analyzer Results

I built the example app's APK and analyzed it.  
As you can see, the warning for `libflutter_zxing.so` is gone.  
The example app now runs correctly on a [16KB page size emulator](https://developer.android.com/guide/practices/page-sizes?hl=en#16kb-emulator) after this change.  
(Without this change, the app crashes immediately.)

| Before | After |
| ------ | ----- |
| <img width="1248" height="587" alt="before" src="https://github.com/user-attachments/assets/164229f8-e3ef-4262-a769-08d7e71b7f4a" /> | <img width="1252" height="587" alt="after" src="https://github.com/user-attachments/assets/efe6bccd-085e-467c-aae6-6387454138f1" /> |