### PR TITLE
✨ add second action button

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -94,6 +94,12 @@ class _DemoPageState extends State<DemoPage> {
                     verticalCropOffset: 0,
                     horizontalCropOffset: 0,
                     tryInverted: true,
+                    onActionSecondButton: () {
+                      setState(() {
+                        showDebugInfo = !showDebugInfo;
+                      });
+                    },
+                    actionSecondButtonIcon: const Icon(Icons.info_outline),
                     tryDownscale: true,
                     maxNumberOfSymbols: 5,
                     scanDelay: Duration(milliseconds: isMultiScan ? 50 : 500),

--- a/lib/src/ui/reader_widget.dart
+++ b/lib/src/ui/reader_widget.dart
@@ -51,8 +51,10 @@ class ReaderWidget extends StatefulWidget {
     this.verticalCropOffset = 0.0,
     this.resolution = ResolutionPreset.high,
     this.lensDirection = CameraLensDirection.back,
-    this.loading =
-        const DecoratedBox(decoration: BoxDecoration(color: Colors.black)),
+    this.loading = const DecoratedBox(decoration: BoxDecoration(color: Colors.black)),
+    this.onActionSecondButton,
+    this.actionSecondButtonIcon,
+    this.actionSecondButtonIconBackgroundColor,
   });
 
   /// Called when a code is detected
@@ -173,6 +175,16 @@ class ReaderWidget extends StatefulWidget {
 
   /// Loading widget while camera is initializing. Default is a black screen
   final Widget loading;
+
+  /// Callback for second action button
+  final Function()? onActionSecondButton;
+
+  /// Second action icon to be displayed on the right side of the action buttons
+  final Widget? actionSecondButtonIcon;
+
+  /// Background color for the second action icon
+  final Color? actionSecondButtonIconBackgroundColor;
+
 
   @override
   State<ReaderWidget> createState() => _ReaderWidgetState();
@@ -594,36 +606,65 @@ class _ReaderWidgetState extends State<ReaderWidget>
             child: Padding(
               padding: widget.actionButtonsPadding,
               child: ClipRRect(
-                borderRadius: widget.actionButtonsBackgroundBorderRadius ??
-                    BorderRadius.circular(10.0),
-                child: ColoredBox(
-                  color: widget.actionButtonsBackgroundColor,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      if (widget.showFlashlight && _isFlashAvailable)
-                        IconButton(
-                          onPressed: _onFlashButtonTapped,
-                          color: Colors.white,
-                          icon: _flashIcon(
-                              controller?.value.flashMode ?? FlashMode.off),
+                borderRadius: widget.actionButtonsBackgroundBorderRadius ?? BorderRadius.circular(10.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    ClipRRect(
+                      borderRadius: widget.actionButtonsBackgroundBorderRadius ??
+                          BorderRadius.circular(10.0),
+                      child: ColoredBox(
+                        color: widget.actionButtonsBackgroundColor,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            if (widget.showFlashlight && _isFlashAvailable)
+                              IconButton(
+                                onPressed: _onFlashButtonTapped,
+                                color: Colors.white,
+                                icon: _flashIcon(
+                                    controller?.value.flashMode ?? FlashMode.off),
+                              ),
+                            if (widget.showGallery)
+                              IconButton(
+                                onPressed: _onGalleryButtonTapped,
+                                color: Colors.white,
+                                icon: widget.galleryIcon,
+                              ),
+                            if (widget.showToggleCamera)
+                              IconButton(
+                                onPressed: _onCameraButtonTapped,
+                                color: Colors.white,
+                                icon: widget.toggleCameraIcon,
+                              ),
+
+                          ],
                         ),
-                      if (widget.showGallery)
-                        IconButton(
-                          onPressed: _onGalleryButtonTapped,
-                          color: Colors.white,
-                          icon: widget.galleryIcon,
+                      ),
+                    ),
+                    if (widget.onActionSecondButton != null && widget.actionSecondButtonIcon != null) ... <Widget>[
+                      Container(
+                        margin: EdgeInsets.only(bottom: (widget.onMultiScanModeChanged != null && widget.multiScanModeAlignment == Alignment.bottomRight) ? 55.0 : 0),
+                        child: IconButton.filled(
+                          padding: widget.actionButtonsPadding,
+                          onPressed: widget.onActionSecondButton,
+                          icon: widget.actionSecondButtonIcon!,
+                          style: IconButton.styleFrom(
+                            backgroundColor: widget.actionSecondButtonIconBackgroundColor ?? widget.actionButtonsBackgroundColor,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: widget.actionButtonsBackgroundBorderRadius ?? BorderRadius.zero,
+                            ),
+                          ),
                         ),
-                      if (widget.showToggleCamera)
-                        IconButton(
-                          onPressed: _onCameraButtonTapped,
-                          color: Colors.white,
-                          icon: widget.toggleCameraIcon,
-                        ),
-                    ],
-                  ),
+                      )
+                    ]
+                  ],
                 ),
               ),
+
+
+
             ),
           ),
         ),


### PR DESCRIPTION
# ✨Feature : Add customizable second action button to ReaderWidget

## Description

This pull request adds support for a **customizable second action button** to the `ReaderWidget` component, allowing developers to provide a callback, icon, and background color for an additional button in the camera UI.

---

## Motivation

Currently, `ReaderWidget` does not supports custom action button.  
Some use cases require an additional button — for example:

- Toggle debug information  
- Open a help/FAQ screen  
- Capture an extra snapshot  
- Trigger a custom action without forking the package  

Adding this feature improves **flexibility** while keeping the widget lightweight and customizable.

---

## Implementation details

- Added new optional properties to `ReaderWidget`:
  - `onActionSecondButton` (callback)  
  - `actionSecondButtonIcon` (icon widget)  
  - `actionSecondButtonIconBackgroundColor` (background color)  
- Updated `_ReaderWidgetState` layout to render the second button with consistent styling and placement.  
- Updated the demo page to demonstrate usage by toggling debug information.  

---

## Example usage

```dart
ReaderWidget(
  onActionSecondButton: () => print("Debug toggle"),
  actionSecondButtonIcon: const Icon(Icons.bug_report),
  actionSecondButtonIconBackgroundColor: Colors.red,
)
```

### Compatibility
	•	✅ Backward compatible: existing users don’t need to change anything.
	•	✅ New properties are optional (null by default).
	•	✅ No breaking changes.

### Documentation / Demo
	•	Added Dartdoc comments for new properties.
	•	Updated the demo page to showcase the new button.
	•	Developers can now try the feature directly in the example app.

### Tests
	•	Tested via the demo page.

### Changelog
	•	feat: add customizable second action button to ReaderWidget


[ Btw this is my first contribution 😃 ] 