### PR TITLE
Multiple Concurrent Isolates Fix

### DIFF
--- a/lib/src/logic/camera_stream.dart
+++ b/lib/src/logic/camera_stream.dart
@@ -4,12 +4,18 @@ IsolateUtils? isolateUtils;
 
 /// Starts reading barcode from the camera
 Future<void> zxingStartCameraProcessing() async {
+  if (isolateUtils != null) {
+    return;
+  }
   isolateUtils = IsolateUtils();
   await isolateUtils?.startReadingBarcode();
 }
 
 /// Stops reading barcode from the camera
-void zxingStopCameraProcessing() => isolateUtils?.stopReadingBarcode();
+void zxingStopCameraProcessing() {
+  isolateUtils?.stopReadingBarcode();
+  isolateUtils = null;
+}
 
 Future<dynamic> zxingProcessCameraImage(
         CameraImage image, DecodeParams params) =>

--- a/lib/src/utils/isolate_utils.dart
+++ b/lib/src/utils/isolate_utils.dart
@@ -32,14 +32,26 @@ class IsolateUtils {
 
   SendPort? get sendPort => _sendPort;
 
-  Future<void> startReadingBarcode() async {
-    _isolate = await Isolate.spawn<SendPort>(
-      readBarcodeEntryPoint,
-      _receivePort.sendPort,
-      debugName: kDebugName,
-    );
+  bool _initializing = false;
 
-    _sendPort = await _receivePort.first;
+  Future<void> startReadingBarcode() async {
+    if (_initializing || _isolate != null) {
+      return;
+    }
+    _initializing = true;
+    try {
+      _isolate = await Isolate.spawn<SendPort>(
+        readBarcodeEntryPoint,
+        _receivePort.sendPort,
+        debugName: kDebugName,
+      );
+
+      _sendPort = await _receivePort.first;
+    } catch (_) {
+      rethrow;
+    } finally {
+      _initializing = false;
+    }
   }
 
   void stopReadingBarcode() {


### PR DESCRIPTION
The way ` zxingStartCameraProcessing` and `IsolateUtils.startReadingBarcode` is written allows for multiple isolates to be created by calling the method again. I stumbled upon this issue when a `Builder` was calling the `initState` of the `ReaderWidget` twice, for some reason. If this happens, then it's a memory leak since there is no way to close the dangling isolate.

This will usually not happen. However, I added guards that disallow it from happening at all. Do check, I haven't tested the code.