### PR TITLE
✨ add second action button

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -94,6 +94,12 @@ class _DemoPageState extends State<DemoPage> {
                     verticalCropOffset: 0,
                     horizontalCropOffset: 0,
                     tryInverted: true,
+                    onActionSecondButton: () {
+                      setState(() {
+                        showDebugInfo = !showDebugInfo;
+                      });
+                    },
+                    actionSecondButtonIcon: const Icon(Icons.info_outline),
                     tryDownscale: true,
                     maxNumberOfSymbols: 5,
                     scanDelay: Duration(milliseconds: isMultiScan ? 50 : 500),

--- a/lib/src/ui/reader_widget.dart
+++ b/lib/src/ui/reader_widget.dart
@@ -51,8 +51,10 @@ class ReaderWidget extends StatefulWidget {
     this.verticalCropOffset = 0.0,
     this.resolution = ResolutionPreset.high,
     this.lensDirection = CameraLensDirection.back,
-    this.loading =
-        const DecoratedBox(decoration: BoxDecoration(color: Colors.black)),
+    this.loading = const DecoratedBox(decoration: BoxDecoration(color: Colors.black)),
+    this.onActionSecondButton,
+    this.actionSecondButtonIcon,
+    this.actionSecondButtonIconBackgroundColor,
   });
 
   /// Called when a code is detected
@@ -173,6 +175,16 @@ class ReaderWidget extends StatefulWidget {
 
   /// Loading widget while camera is initializing. Default is a black screen
   final Widget loading;
+
+  /// Callback for second action button
+  final Function()? onActionSecondButton;
+
+  /// Second action icon to be displayed on the right side of the action buttons
+  final Widget? actionSecondButtonIcon;
+
+  /// Background color for the second action icon
+  final Color? actionSecondButtonIconBackgroundColor;
+
 
   @override
   State<ReaderWidget> createState() => _ReaderWidgetState();
@@ -594,36 +606,65 @@ class _ReaderWidgetState extends State<ReaderWidget>
             child: Padding(
               padding: widget.actionButtonsPadding,
               child: ClipRRect(
-                borderRadius: widget.actionButtonsBackgroundBorderRadius ??
-                    BorderRadius.circular(10.0),
-                child: ColoredBox(
-                  color: widget.actionButtonsBackgroundColor,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      if (widget.showFlashlight && _isFlashAvailable)
-                        IconButton(
-                          onPressed: _onFlashButtonTapped,
-                          color: Colors.white,
-                          icon: _flashIcon(
-                              controller?.value.flashMode ?? FlashMode.off),
+                borderRadius: widget.actionButtonsBackgroundBorderRadius ?? BorderRadius.circular(10.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    ClipRRect(
+                      borderRadius: widget.actionButtonsBackgroundBorderRadius ??
+                          BorderRadius.circular(10.0),
+                      child: ColoredBox(
+                        color: widget.actionButtonsBackgroundColor,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            if (widget.showFlashlight && _isFlashAvailable)
+                              IconButton(
+                                onPressed: _onFlashButtonTapped,
+                                color: Colors.white,
+                                icon: _flashIcon(
+                                    controller?.value.flashMode ?? FlashMode.off),
+                              ),
+                            if (widget.showGallery)
+                              IconButton(
+                                onPressed: _onGalleryButtonTapped,
+                                color: Colors.white,
+                                icon: widget.galleryIcon,
+                              ),
+                            if (widget.showToggleCamera)
+                              IconButton(
+                                onPressed: _onCameraButtonTapped,
+                                color: Colors.white,
+                                icon: widget.toggleCameraIcon,
+                              ),
+
+                          ],
                         ),
-                      if (widget.showGallery)
-                        IconButton(
-                          onPressed: _onGalleryButtonTapped,
-                          color: Colors.white,
-                          icon: widget.galleryIcon,
+                      ),
+                    ),
+                    if (widget.onActionSecondButton != null && widget.actionSecondButtonIcon != null) ... <Widget>[
+                      Container(
+                        margin: EdgeInsets.only(bottom: (widget.onMultiScanModeChanged != null && widget.multiScanModeAlignment == Alignment.bottomRight) ? 55.0 : 0),
+                        child: IconButton.filled(
+                          padding: widget.actionButtonsPadding,
+                          onPressed: widget.onActionSecondButton,
+                          icon: widget.actionSecondButtonIcon!,
+                          style: IconButton.styleFrom(
+                            backgroundColor: widget.actionSecondButtonIconBackgroundColor ?? widget.actionButtonsBackgroundColor,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: widget.actionButtonsBackgroundBorderRadius ?? BorderRadius.zero,
+                            ),
+                          ),
                         ),
-                      if (widget.showToggleCamera)
-                        IconButton(
-                          onPressed: _onCameraButtonTapped,
-                          color: Colors.white,
-                          icon: widget.toggleCameraIcon,
-                        ),
-                    ],
-                  ),
+                      )
+                    ]
+                  ],
                 ),
               ),
+
+
+
             ),
           ),
         ),


### PR DESCRIPTION
This pull request adds support for a customizable second action button to the `ReaderWidget` component, allowing developers to easily add an additional action (such as showing debug information) to the camera interface. The changes include new properties for the button's callback, icon, and background color, and update the UI to display the button conditionally.

**New customizable second action button:**

* Added new properties to `ReaderWidget` for a second action button: `onActionSecondButton`, `actionSecondButtonIcon`, and `actionSecondButtonIconBackgroundColor`, allowing users to specify the callback, icon, and background color for the button. [[1]](diffhunk://#diff-d56a8496d17150c58a507f8d66168ac1d0f970c08d05c242a933fdb602741733L54-R57) [[2]](diffhunk://#diff-d56a8496d17150c58a507f8d66168ac1d0f970c08d05c242a933fdb602741733R179-R188)
* Updated the layout in `_ReaderWidgetState` to conditionally display the second action button on the right side of the action buttons row, including proper styling and alignment. [[1]](diffhunk://#diff-d56a8496d17150c58a507f8d66168ac1d0f970c08d05c242a933fdb602741733R609-R614) [[2]](diffhunk://#diff-d56a8496d17150c58a507f8d66168ac1d0f970c08d05c242a933fdb602741733R641-R667)

**Example usage in demo page:**

* Implemented the second action button in the demo page, toggling the display of debug information when pressed and using the `Icons.info_outline` icon.