### PR TITLE
Ensure torch toggle button is hidden when flash is unavailable

### DIFF
--- a/lib/src/ui/reader_widget.dart
+++ b/lib/src/ui/reader_widget.dart
@@ -408,7 +408,11 @@ class _ReaderWidgetState extends State<ReaderWidget>
         }
       }
     } catch (e) {
-      _isFlashAvailable = false;
+      if (e is CameraException && e.code == 'setFlashModeFailed') {
+        setState(() {
+          _isFlashAvailable = false;
+        });
+      }
       widget.onControllerCreated
           ?.call(null, e is Exception ? e : Exception(e.toString()));
     } finally {


### PR DESCRIPTION
This makes sure that the button for toggling the camera flash is not displayed when the camera does not support setting the `FlashMode` (for example because no flash is available).
Technically this still does not guarantee that setting it to `FlashMode.torch` will be supported, but this should be good enough nevertheless.

The most minimal fix would be this (only adding the `setState`), but I figured wrapping it in the condition does make the logic more resilient:
```dart
  setState(() {
    _isFlashAvailable = false;
  });
```