### PR TITLE
Remove linter rules removed in Dart 3.3.0

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -37,7 +37,6 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_require_non_null_named_parameters
     - always_specify_types
     # - always_use_package_imports # we do this commonly
     - annotate_overrides
@@ -67,7 +66,6 @@ linter:
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
     # - avoid_returning_null # still violated by some pre-nnbd code that we haven't yet migrated
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     # - avoid_returning_this # there are enough valid reasons to return `this` that this lint ends up with too many false positives
     - avoid_setters_without_getters
@@ -145,7 +143,6 @@ linter:
     # - prefer_constructors_over_static_methods # far too many false positives
     - prefer_contains
     # - prefer_double_quotes # opposite of prefer_single_quotes
-    - prefer_equal_for_default_values
     # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     - prefer_final_in_for_each


### PR DESCRIPTION
On my machine using Dart 3.11, I get the following analyzer warning about removed rules:
```
user@machine flutter_zxing > dart analyze
Analyzing flutter_zxing...             4.2s

warning • analysis_options.yaml:40:7 • 'always_require_non_null_named_parameters' was removed in Dart '3.3.0' Try removing the reference to
          'always_require_non_null_named_parameters'. • removed_lint
warning • analysis_options.yaml:70:7 • 'avoid_returning_null_for_future' was removed in Dart '3.3.0' Try removing the reference to
          'avoid_returning_null_for_future'. • removed_lint
warning • analysis_options.yaml:148:7 • 'prefer_equal_for_default_values' was removed in Dart '3.0.0' Try removing the reference to
          'prefer_equal_for_default_values'. • removed_lint
```

I removed these rules and now `dart analyze` completes without any warnings.