### PR TITLE
fixes error: stopImageStream() was called on an uninitialized CameraC…

### DIFF
--- a/lib/src/ui/reader_widget.dart
+++ b/lib/src/ui/reader_widget.dart
@@ -325,7 +325,7 @@ class _ReaderWidgetState extends State<ReaderWidget>
   }
 
   void _stopCamera() {
-    if ((controller?.value.isStreamingImages ?? false) == false) {
+    if (controller?.value.isStreamingImages ?? false) {
       try {
         controller?.stopImageStream();
       } catch (e) {


### PR DESCRIPTION
Fixes the issue in v2.2.1 of upstream repo - that

stopImageStream() was called on an uninitialized CameraController

See https://github.com/khoren93/flutter_zxing/issues/212