### PR TITLE
Also link dynamically when using Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@
 .packages
 build/
 
-# iOS and MacOS src folders
+# iOS and MacOS src and .build folders
 ios/flutter_zxing/Sources/
+ios/flutter_zxing/.build/
 macos/flutter_zxing/Sources/
+macos/flutter_zxing/.build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+
+* Fixed iOS/macOS barcode detection failing in stripped archives after the SPM migration.
+
 ## 2.3.0
 
 * Migrated iOS and macOS projects from CocoaPods to Swift Package Manager (SPM).

--- a/ios/flutter_zxing/Package.swift
+++ b/ios/flutter_zxing/Package.swift
@@ -9,7 +9,13 @@ let package = Package(
         .iOS("13.0")
     ],
     products: [
-        .library(name: "flutter-zxing", targets: ["flutter_zxing"])
+        // Must be a dynamic library. The Dart side resolves the FFI entry
+        // points at runtime via `DynamicLibrary.process()`. As a static library
+        // these symbols are linked into the app's executable, where the App
+        // Store archive's `strip` step removes them, breaking barcode detection.
+        // A dynamic framework keeps them in its export table, which `strip`
+        // preserves and `dlsym` can still find.
+        .library(name: "flutter-zxing", type: .dynamic, targets: ["flutter_zxing"])
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework")

--- a/macos/flutter_zxing/Package.swift
+++ b/macos/flutter_zxing/Package.swift
@@ -9,7 +9,13 @@ let package = Package(
         .macOS("10.15")
     ],
     products: [
-        .library(name: "flutter-zxing", targets: ["flutter_zxing"])
+        // Must be a dynamic library. The Dart side resolves the FFI entry
+        // points at runtime via `DynamicLibrary.process()`. As a static library
+        // these symbols are linked into the app's executable, where the App
+        // Store archive's `strip` step removes them, breaking barcode detection.
+        // A dynamic framework keeps them in its export table, which `strip`
+        // preserves and `dlsym` can still find.
+        .library(name: "flutter-zxing", type: .dynamic, targets: ["flutter_zxing"])
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_zxing
 description: A barcode scanner and generator natively in Flutter with Dart FFI based on ZXing.
-version: 2.3.0
+version: 2.3.1
 repository: https://github.com/khoren93/flutter_zxing
 
 environment:


### PR DESCRIPTION
This is a critical fix for iOS and macOS after the migration to Swift Package Manager.

## Background
Albeit `flutter run` and `flutter run --release` work just fine for iOS at the moment, in an app built for distribution with `flutter build ipa`, the barcode detection does not work at all.

The reason for this is that during archiving [XCode strips exported symbols by default](https://github.com/flutter/flutter/issues/62666).

## Fix
I fixed the regression by using dynamic linking as has been done with CocoaPods before.

## Validation
Because I found it rather difficult to pin-point / validate the issue initially, I thought I'd provide a small overview for how to do it with the sample app, just in case you want to verify the change.

1. Optionally prepare native source if needed with `git submodule update --init --recursive && ./scripts/update_ios_macos_src.sh`
2. `cd example`
3. `flutter pub get`
4. `cd ios`
5. Run archive build (which includes stripping)
```bash
xcodebuild \
  -workspace Runner.xcworkspace \
  -scheme Runner \
  -configuration Release \
  -sdk iphoneos \
  -archivePath /tmp/Runner.xcarchive \
  archive \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
```
6. Check if symbols are still there (with the fix they are still present, without it you have to check a bit different; See below):
```bash
xcrun dyld_info -exports "/tmp/Runner.xcarchive/Products/Applications/Runner.app/Frameworks/flutter-zxing.framework/flutter-zxing" \
  | grep -E '_readBarcode$|_readBarcodes$|_encodeBarcode$|_setLogEnabled$|_version$'
```
or
```bash
nm -gU "/tmp/Runner.xcarchive/Products/Applications/Runner.app/Frameworks/flutter-zxing.framework/flutter-zxing" \
  | grep -E '_readBarcode$|_readBarcodes$|_encodeBarcode$|_setLogEnabled$|_version$'
```

Note that the whole framework is gone with the current `main` branch (you can for example verify this with `otool -L "/tmp/Runner.xcarchive/Products/Applications/Runner.app/Runner" | grep zxing` which does not find the framework on main, but does with the fix), but you can still somewhat verify the issue, by checking if the symbols are present in the statically linked app:
```bash
nm "/tmp/Runner.xcarchive/Products/Applications/Runner.app/Runner" | grep -E '_readBarcode|_readBarcodes|_encodeBarcode'
```
as you will see the symbols are not present which means they were stripped out by XCode.

## Alternative
Alternatively we could instruct users in the README to [enable the `Non-Global Symbols` `Strip Style` in their iOS and macOS XCode projects](https://docs.flutter.dev/platform-integration/legacy-ffi-plugin#ios-stripping-symbols) and keep linking statically, but I think providing a central fix here, that also aligns with the previous behavior when using CocoaPods is the preferred option.

## Notes on the PR
1. I also included the `.build/` directory of the native iOS and macOS projects in the `.gitignore` which is the standard practice
2. I prepared the library for a new release by bumping the version and updating the Changelog, because I think this fix is critical enough for a new release, but if you disagree or want to do this yourself I can remove that commit?