### PR TITLE
Remove NT_GNU_BUILD_ID from build to support reproducible building

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ if (ANDROID)
 
     # Required for 16KB page size support on NDK 27.x. NDK 28+ already defaults
     # to 16KB, where this option is simply a no-op, so it is safe either way.
-    target_link_options(flutter_zxing PRIVATE "-Wl,-z,max-page-size=16384")
+    target_link_options(flutter_zxing PRIVATE "-Wl,-z,max-page-size=16384,--build-id=none")
 endif (ANDROID)
 
 # Command to update zxing submodule


### PR DESCRIPTION
Add the `--build-id=none` linker flag to remove the `NT_GNU_BUILD_ID` note from the libflutter_zxing.so library file in the generated APK. This note depends on the build environment info and prevents builds from being reproducible, which is kinda required by F-Droid now.