### PR TITLE
feat: Try to keep previous zoom level when switching cameras

### DIFF
--- a/lib/src/ui/reader_widget.dart
+++ b/lib/src/ui/reader_widget.dart
@@ -537,8 +537,17 @@ class _ReaderWidgetState extends State<ReaderWidget>
         _maxZoomLevel = 1.0;
       }
       // A new camera has its own zoom range; carrying the previous one over
-      // would apply a factor this camera may not support.
-      _scaleFactor = _minZoomLevel;
+      // unconditionally would apply a factor this camera may not support.
+      _scaleFactor = _scaleFactor.clamp(_minZoomLevel, _maxZoomLevel);
+
+      try {
+        await cameraController.setZoomLevel(_scaleFactor);
+      } catch (e) {
+        debugPrint(
+          'Failed to set camera zoom level. Resetting scale factor to 1.0',
+        );
+        _scaleFactor = 1.0;
+      }
 
       if (!isCurrent()) {
         return;


### PR DESCRIPTION
This PR proposes to change the current behavior of resetting the zoom level when switching between to cameras.

The current behavior would for example lead to this:
1. Zoom in with back facing camera
2. Switch to front facing camera (zoom level is reset)
3. Switch back to back facing camera (zoom level is still reset)

With this proposal it could be that the previous zoom level is kept all the way, under the premise that the front facing camera also supports this zoom level (if it does not, the zoom is clamped).

I can find arguments for both ways to handle this and my proposal certainly isn't perfect either. If you like the current approach better, please feel free to close this PR.